### PR TITLE
feat!: content-derived stable node IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,13 +18,41 @@ ever grows in default mode — see *Compatibility* below).
   id was meaningless outside the run that produced it. An id is now a
   blake3 hash of the node's own identity — a file's relative path, or a
   callable's `(language, file path, owner qualified name, qualified
-  name)` — so **the same node gets the same id on every run**, and
-  adding or removing an unrelated node elsewhere in the tree never
-  changes ids that didn't collide with it. Collisions are vanishingly
-  rare (52 bits of hash by default) and, on the rare case, resolved by
-  pulling more bits from the same node's own hash stream — never by
-  comparing to whichever other node it collided with — so the property
-  above holds even across a collision.
+  name, signature hint)` — so **the same node gets the
+  same id on every run**, and adding, removing or editing an unrelated
+  file never changes it.
+
+  The signature is part of the key because the first four components are
+  **not unique**. A file that declares several callables sharing a
+  qualified name — overloads, which C++, C#, Java and Erlang have in
+  quantity — hashes them identically. Over the 113-repo benchmark corpus
+  that is **309,347 of 1,745,670 callables (17.7%)**, peaking at 52.8%
+  in one repo, and every one of them falls through to the collision path
+  where the id is decided by declaration order rather than content. That
+  breaks the guarantee this change exists to provide: delete the first
+  of two overloads and the second inherits its id, so a consumer diffing
+  ids across runs reads "unchanged" while the id now names a different
+  function. Including the signature takes that population to **2.25%** —
+  the residual being callables cgg genuinely cannot tell apart, where no
+  key can do better.
+
+  `start_byte` was measured as an alternative and rejected. It is unique
+  corpus-wide, but it churns on movement — one comment line added at the
+  top of `spdlog`'s busiest header moved 135 of 1,157 ids, destroying
+  the diffability this change exists for — and it still lets a survivor
+  inherit a deleted sibling's id, because removing a definition shifts
+  the next one into its byte offset.
+
+  What holds: editing an unrelated file changes nothing, moving code
+  within a file changes nothing (verified by running `cargo fmt --all`
+  over cgg's own tree — 318 callables, 0 ids changed), and removing one
+  overload leaves its siblings alone.
+
+  A collision, if one ever occurs, is resolved by drawing the next
+  window from the same node's own hash stream — never by comparing to
+  whichever other node it collided with. Every draw is 52 bits wide, so
+  **no id ever exceeds 52 bits**; that bound is what keeps `cgg-node`'s
+  `number` binding exact.
 
   **Wire format changed too.** An id used to be a bare integer
   (`{"src": 0, "dst": 1}` in JSON; `C0`, `n0` in mermaid/dot/graphml).
@@ -40,11 +68,14 @@ ever grows in default mode — see *Compatibility* below).
   run, so a diff against a previous run's ids is now meaningful for the
   first time — but a diff against pre-upgrade output will show every id
   as new, once. `cgg-py`'s `Callable.id`/`Edge.src`/`Edge.dst`/
-  `Edge.file`/`File.id` are `u64` now (Python's `int` already covers
-  the range, so nothing on the Python side needed a type change beyond
-  that). `cgg-node`'s equivalents are `bigint` now — a required change
-  since N-API has no native `u64` binding, so `number` was no longer
-  safe. `cgg-node`'s `Graph.files` getter, which used to return
+  `File.id` are `u64` now (Python's `int` already covers the range, so
+  nothing on the Python side needed a type change beyond that).
+  `cgg-node`'s equivalents are `i64` on the Rust side and `number` in
+  the generated `index.d.ts` — N-API has no native `u64` binding, and
+  `number` is exact here only because every id stays inside 52 bits,
+  comfortably under `Number.MAX_SAFE_INTEGER` (2^53-1).
+  Verified: across the corpus no `cgg-node` id is negative, unsafe, or
+  disagrees with the value the CLI reports for the same callable. `cgg-node`'s `Graph.files` getter, which used to return
   `Array<string>` of bare paths indexed by `Callable.file`, now returns
   `Array<{ id, path }>` — matching by id was already how `cgg-py`
   worked, and the old "index equals id" invariant depended on the
@@ -54,12 +85,40 @@ ever grows in default mode — see *Compatibility* below).
 
 ### Performance
 
-- Not yet measured. `scripts/perf-compare.sh` needs to run against a
-  baseline binary before release — content-derived ids trade a
-  sequential counter for a blake3 hash per node plus a `HashSet`
-  membership check for collision detection, so this is expected to
-  have *some* per-node cost, but "measure, never estimate" applies:
-  no number is claimed here until it's been run.
+- Measured with `scripts/perf-compare.sh main 7` — median of 7 runs per
+  repo, alternating which binary goes first. The corpus budget stopped
+  the sweep after **67 of 113 repos** (alphabetical prefix, through
+  `erlang-otp`); that is disclosed rather than presented as full
+  coverage.
+
+  | comparison | median per-repo | total (excl. `erlang-otp`) |
+  | --- | --- | --- |
+  | content-derived ids vs `main` | **+3.5%** | +2.9% |
+
+  So the feature costs roughly **3%**, which is the blake3 hash and
+  `HashSet` probe per callable replacing an integer increment. Against
+  the harness's own stated noise floor of 1–1.5% on a total, the
+  per-repo median is a real cost, not jitter.
+
+  **`erlang-otp` is excluded from the totals above and the exclusion is
+  the point.** The same binary measured 26,651 ms in one sweep and
+  36,280 ms in another — a 36% spread with no code change between them.
+  A direct alternating measurement (5 samples, median) puts it at
+  **26.9 s against `main`'s 28.1 s**, i.e. slightly *faster*, so the
+  large positive deltas that appear for it in some sweeps are machine
+  contention rather than a regression. It is 28% of the corpus total, so
+  leaving it in swings the headline number by ten points in either
+  direction. This is the same trap CLAUDE.md records for 0.6.x: quote
+  the median, not a total one repo can dominate.
+
+  Two changes in this branch were made *because* they were measured, not
+  because they looked cleaner. Keeping the mermaid/dot dedup keys `Copy`
+  avoids two `String` allocations per edge plus two more per lookup. And
+  the redundant `include_by_last` sort in `cross_file.rs` was dropped
+  rather than re-keyed: sorting those buckets by `PathBuf` to restore
+  discovery order cost **+30% on `erlang-otp`** on its own, and the
+  buckets are already built in discovery order, so the sort was never
+  doing anything.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,60 @@ ever grows in default mode — see *Compatibility* below).
 
 ## [Unreleased]
 
+### Changed — BREAKING: node ids are content-derived, not sequential
+
+- **`CallableId`/`FileId` are now stable, content-derived hashes instead
+  of a per-run sequential counter.** Every emitted graph — mermaid,
+  json, dot, graphml — previously numbered nodes `0, 1, 2, …` in
+  file-discovery order, so the same source tree could mint a different
+  id for the same function from one run to the next (a new file
+  appearing earlier in the walk order shifts every id after it), and an
+  id was meaningless outside the run that produced it. An id is now a
+  blake3 hash of the node's own identity — a file's relative path, or a
+  callable's `(language, file path, owner qualified name, qualified
+  name)` — so **the same node gets the same id on every run**, and
+  adding or removing an unrelated node elsewhere in the tree never
+  changes ids that didn't collide with it. Collisions are vanishingly
+  rare (52 bits of hash by default) and, on the rare case, resolved by
+  pulling more bits from the same node's own hash stream — never by
+  comparing to whichever other node it collided with — so the property
+  above holds even across a collision.
+
+  **Wire format changed too.** An id used to be a bare integer
+  (`{"src": 0, "dst": 1}` in JSON; `C0`, `n0` in mermaid/dot/graphml).
+  It is now the type's prefix character followed by lowercase base36
+  digits (`{"src": "C4k2j9qh3xz"}`; `Chco17z7ulm`, `nhco17z7ulm`). This
+  is unconditional — there is no flag and no fallback to the old
+  numeric scheme, because only a handful of consumers depend on raw id
+  values today and every one of them (the CLI's own formatters,
+  `cgg-py`, `cgg-node`) was updated in this same change.
+
+  **If you store or diff raw ids across runs, this changes what you see
+  even though the graph is unchanged**: ids no longer renumber on every
+  run, so a diff against a previous run's ids is now meaningful for the
+  first time — but a diff against pre-upgrade output will show every id
+  as new, once. `cgg-py`'s `Callable.id`/`Edge.src`/`Edge.dst`/
+  `Edge.file`/`File.id` are `u64` now (Python's `int` already covers
+  the range, so nothing on the Python side needed a type change beyond
+  that). `cgg-node`'s equivalents are `bigint` now — a required change
+  since N-API has no native `u64` binding, so `number` was no longer
+  safe. `cgg-node`'s `Graph.files` getter, which used to return
+  `Array<string>` of bare paths indexed by `Callable.file`, now returns
+  `Array<{ id, path }>` — matching by id was already how `cgg-py`
+  worked, and the old "index equals id" invariant depended on the
+  sequential scheme this change removes. `cgg-ffi`'s C ABI is
+  unaffected: it never exposed raw ids, only rendered strings/JSON, by
+  design.
+
+### Performance
+
+- Not yet measured. `scripts/perf-compare.sh` needs to run against a
+  baseline binary before release — content-derived ids trade a
+  sequential counter for a blake3 hash per node plus a `HashSet`
+  membership check for collision detection, so this is expected to
+  have *some* per-node cost, but "measure, never estimate" applies:
+  no number is claimed here until it's been run.
+
 ### Added
 
 - **Google Cloud Functions, Azure Functions, Firebase, Cloudflare

--- a/README.md
+++ b/README.md
@@ -510,7 +510,7 @@ through the Python plugin (`!`, `%`, `?` magics stripped automatically).
 
 ## Self-analysis
 
-`cgg` run on its own source <!-- cgg:begin:self-stats -->(2088 callables, 4963 edges, 1785 cross-file, 119ms)<!-- cgg:end:self-stats -->. This is the 1-hop neighborhood of `cgg::analyze_in_pool`, the pipeline <!-- markdownlint-disable-line MD013 -->
+`cgg` run on its own source <!-- cgg:begin:self-stats -->(2090 callables, 4974 edges, 1788 cross-file, 138ms)<!-- cgg:end:self-stats -->. This is the 1-hop neighborhood of `cgg::analyze_in_pool`, the pipeline <!-- markdownlint-disable-line MD013 -->
 body — every edge is a real cross-crate function call, and the fan-out is
 the resolver ordering described under [How it works](#how-it-works):
 
@@ -521,135 +521,135 @@ cgg ./crates -t mermaid --filter 'cgg::analyze_in_pool$' -n 1
 <!-- cgg:begin:self -->
 ```mermaid
 flowchart LR
-  Ce8btaz0c7d["cgg::deadcode::config::DeadCodeConfigFile::load"]
-  C1fuqoee162["cgg::deadcode::config::DeadCodeConfigFile::discover_for"]
-  Cu8sm37x27i["cgg::analyze"]
-  Ck6rdns31fh["cgg::analyze_in_pool"]
-  Cisqfzflkw2["cgg::langs_enabled"]
-  C7vl7hj6da0["cgg::specific"]
-  Cc6430xzlhv["cgg::dead_code_analysis"]
-  Cyb8lff0cu6["cgg::why_live_proofs"]
-  Crazkm27b4n["cgg::since_seeds"]
-  Ce6100aa7pb["cgg::count_lines"]
-  Cd2jp9c8iji["cgg::read_file"]
-  C4uh9t2boar["cgg::variant_to_kind"]
-  Cyuotlqx8cg["cgg::synthesize_exit_nodes"]
-  C14txnctguqp["cgg::synthesize_entry_nodes"]
-  C110r2j3hgh3["cgg::trait_impl_target_from_qn"]
-  C12cl5iiregd["cgg::dedup_edges"]
-  Coz7jqry0jt["cgg::group_unresolved_by_module"]
-  Civon2m7kiq["cgg::options::RunOptions::dead_mode"]
-  Cpdmf2f970w["cgg::outcome::Emission::line"]
-  Co9lkohbv7["cgg::outcome::Emission::always"]
-  Cikry60zwgd["cgg::query::apply_query"]
-  Cegjh02oqxa["cgg::query::apply_exclusions"]
-  Cjn5qmo68zf["cgg::since::resolve_since"]
-  Cjwpbtnrpq9["cgg::stable_ids::StableIds::new"]
-  Cr37f9vwja4["cgg::stable_ids::StableIds::file"]
-  C7x7z80po60["cgg::stable_ids::StableIds::callable"]
-  C9dybi363du["cgg_core::external::FileAliases::from_facts"]
-  Cr8fsp2a2yv["cgg_core::external::classify_external"]
-  C1763zjuiemp["cgg_core::external::build_known_names"]
-  C7b3b3l1lm6["cgg_core::graph::Graph::new"]
-  Cuqpquw4s0d["cgg_core::graph::Graph::add_callable"]
-  C11hq6v37tdw["cgg_core::graph::Graph::add_file"]
-  Cns9jydj0k1["cgg_core::graph::Graph::add_edge"]
-  Cl392qv0r5a["cgg_core::profile::enable"]
-  Chptg76umzv["cgg_core::profile::span"]
-  C2lsittm2s4["cgg_core::testfile::classify_test_file"]
-  C10q0avqswp9["cgg_lang::detect::LanguageDetector&lt;'r&gt;::new"]
-  Cp7bq4qiwgz["cgg_lang::detect::LanguageDetector&lt;'r&gt;::detect"]
-  C59pox1dp6q["cgg_lang::ExtractCtx&lt;'a&gt;::for_language"]
-  Ctdg6zm99p3["cgg_lang::PluginRegistry::with_v1_plugins"]
-  C184und02q38["cgg_lang::notebook::extract_python_source"]
-  Ckwi21q4n99["cgg_lang::parser::ParserPool&lt;'r&gt;::new"]
-  C26bd5qoaul["cgg_lang::parser::ParserPool&lt;'r&gt;::parse"]
-  C6jcyyvmxks["cgg_lang::parser::ParserPool&lt;'r&gt;::plugin"]
-  C14crdads27m["cgg_resolve::cross_file::resolve"]
-  Cf3d62vvukt["cgg_resolve::descriptor::link_descriptors"]
-  Cbuowmgsuna["cgg_resolve::dispatch::fanout"]
-  C92h1zyobno["cgg_resolve::ffi::link_ffi"]
-  Cm7bu22jhwg["cgg_resolve::frameworks::detect"]
-  Ckwpvjofrwg["cgg_resolve::intra_file::link_file"]
-  C92stn8ydvj["cgg_resolve::names::owner_from_qn"]
-  C83eo6qi9sg["cgg_resolve::type_hints::build_return_type_map"]
-  C652z8l1h5w["cgg_resolve::type_hints::propagate_types_with_returns"]
-  Chco17z7ulm["cgg_walk::walk"]
-  Cu8sm37x27i --> Ck6rdns31fh
-  Ck6rdns31fh --> Cisqfzflkw2
-  Ck6rdns31fh --> Cd2jp9c8iji
-  Ck6rdns31fh --> Ce6100aa7pb
-  Ck6rdns31fh --> C4uh9t2boar
-  Ck6rdns31fh --> C110r2j3hgh3
-  Ck6rdns31fh -->|2x| C7vl7hj6da0
-  Ck6rdns31fh --> Cyuotlqx8cg
-  Ck6rdns31fh --> C14txnctguqp
-  Ck6rdns31fh --> Coz7jqry0jt
-  Ck6rdns31fh --> C12cl5iiregd
-  Ck6rdns31fh --> Crazkm27b4n
-  Ck6rdns31fh --> Cyb8lff0cu6
-  Ck6rdns31fh --> Cc6430xzlhv
-  C26bd5qoaul --> C26bd5qoaul
-  Ck6rdns31fh --> Civon2m7kiq
-  Ck6rdns31fh --> C1fuqoee162
-  Ck6rdns31fh --> Ce8btaz0c7d
-  Ck6rdns31fh --> Cl392qv0r5a
-  Ck6rdns31fh --> Chco17z7ulm
-  Ck6rdns31fh --> Ctdg6zm99p3
-  Ck6rdns31fh --> C10q0avqswp9
-  Ck6rdns31fh --> Ckwi21q4n99
-  Ck6rdns31fh --> Cjwpbtnrpq9
-  Ck6rdns31fh --> C7b3b3l1lm6
-  Ck6rdns31fh --> Cp7bq4qiwgz
-  Ck6rdns31fh --> C184und02q38
-  Ck6rdns31fh -->|18x| Chptg76umzv
-  Ck6rdns31fh --> C26bd5qoaul
-  Ck6rdns31fh --> C6jcyyvmxks
-  Ck6rdns31fh --> C59pox1dp6q
-  Ck6rdns31fh --> Cr37f9vwja4
-  Ck6rdns31fh --> C2lsittm2s4
-  Ck6rdns31fh --> C11hq6v37tdw
-  Ck6rdns31fh --> C92stn8ydvj
-  Ck6rdns31fh --> C7x7z80po60
-  Ck6rdns31fh --> Cuqpquw4s0d
-  Ck6rdns31fh --> C83eo6qi9sg
-  Ck6rdns31fh --> C652z8l1h5w
-  Ck6rdns31fh --> C1763zjuiemp
-  Ck6rdns31fh --> Ckwpvjofrwg
-  Ck6rdns31fh --> C9dybi363du
-  Ck6rdns31fh --> Cr8fsp2a2yv
-  Ck6rdns31fh --> C14crdads27m
-  Ck6rdns31fh --> C92h1zyobno
-  Ck6rdns31fh --> Cf3d62vvukt
-  Ck6rdns31fh --> Cm7bu22jhwg
-  Ck6rdns31fh --> Cbuowmgsuna
-  Ck6rdns31fh --> Cns9jydj0k1
-  Ck6rdns31fh -->|5x| Cpdmf2f970w
-  Ck6rdns31fh --> Cjn5qmo68zf
-  Ck6rdns31fh -->|2x| Co9lkohbv7
-  Ck6rdns31fh --> Cikry60zwgd
-  Ck6rdns31fh --> Cegjh02oqxa
-  Cc6430xzlhv --> Ctdg6zm99p3
-  Cc6430xzlhv --> Co9lkohbv7
-  Cc6430xzlhv --> Cpdmf2f970w
-  Cyb8lff0cu6 --> Co9lkohbv7
-  Cyuotlqx8cg -->|2x| Cr37f9vwja4
-  Cyuotlqx8cg -->|2x| C11hq6v37tdw
-  Cyuotlqx8cg --> C7x7z80po60
-  Cyuotlqx8cg --> Cuqpquw4s0d
-  Cyuotlqx8cg --> Cns9jydj0k1
-  C14txnctguqp --> Cr37f9vwja4
-  C14txnctguqp --> C11hq6v37tdw
-  C14txnctguqp --> C7x7z80po60
-  C14txnctguqp --> Cuqpquw4s0d
-  C14txnctguqp --> Cns9jydj0k1
-  Cikry60zwgd --> C7b3b3l1lm6
-  C14crdads27m -->|6x| Chptg76umzv
-  C14crdads27m -->|4x| C92stn8ydvj
-  Cf3d62vvukt -->|2x| C92stn8ydvj
-  Cbuowmgsuna --> C92stn8ydvj
-  Cm7bu22jhwg -->|9x| Chptg76umzv
-  Ckwpvjofrwg -->|3x| C92stn8ydvj
+  Cods529o10n["cgg::deadcode::config::DeadCodeConfigFile::load"]
+  Cd1xvlrrdww["cgg::deadcode::config::DeadCodeConfigFile::discover_for"]
+  Ct0c2ixgmx8["cgg::analyze"]
+  C12m1b7egd7a["cgg::analyze_in_pool"]
+  Cgbax03cjph["cgg::langs_enabled"]
+  Cpbf1nw0gl7["cgg::specific"]
+  C1415sed6gsk["cgg::dead_code_analysis"]
+  C405rboiqlv["cgg::why_live_proofs"]
+  Clv6vms0oi1["cgg::since_seeds"]
+  Chj8h5ziozb["cgg::count_lines"]
+  Ci4p2rb43rp["cgg::read_file"]
+  C2f1t66864d["cgg::variant_to_kind"]
+  Ck4ptx27z7x["cgg::synthesize_exit_nodes"]
+  Clwcttx5lpo["cgg::synthesize_entry_nodes"]
+  Ctfmoqi85tg["cgg::trait_impl_target_from_qn"]
+  Cwqkqak75tl["cgg::dedup_edges"]
+  Coix60lhqf7["cgg::group_unresolved_by_module"]
+  Crtsepedphw["cgg::options::RunOptions::dead_mode"]
+  C142sy5bd6bx["cgg::outcome::Emission::line"]
+  Ct77oun8kqo["cgg::outcome::Emission::always"]
+  Cjqock7evo5["cgg::query::apply_query"]
+  C12wdyqabzvp["cgg::query::apply_exclusions"]
+  Ce8lkrr7qkj["cgg::since::resolve_since"]
+  Cbgxp5y3jf4["cgg::stable_ids::StableIds::new"]
+  Cka7z9fgizy["cgg::stable_ids::StableIds::file"]
+  C14uv2ki067t["cgg::stable_ids::StableIds::callable"]
+  Cbs4im1rijt["cgg_core::external::FileAliases::from_facts"]
+  Cuqf7vje4v5["cgg_core::external::classify_external"]
+  Cm5zypciozo["cgg_core::external::build_known_names"]
+  Cf51o5g9qy0["cgg_core::graph::Graph::new"]
+  C1wzvx79ql2["cgg_core::graph::Graph::add_callable"]
+  Cihr3kfyvtu["cgg_core::graph::Graph::add_file"]
+  Ch84iv4wac8["cgg_core::graph::Graph::add_edge"]
+  Ccyvdjxcoox["cgg_core::profile::enable"]
+  Cje1i47p3yv["cgg_core::profile::span"]
+  Cekb0n2g1eg["cgg_core::testfile::classify_test_file"]
+  C17o9pp22qiz["cgg_lang::detect::LanguageDetector&lt;'r&gt;::new"]
+  C14fkc4o8c6d["cgg_lang::detect::LanguageDetector&lt;'r&gt;::detect"]
+  Co7i2la9csu["cgg_lang::ExtractCtx&lt;'a&gt;::for_language"]
+  C12pncd15md4["cgg_lang::PluginRegistry::with_v1_plugins"]
+  Ciutkm7qyvn["cgg_lang::notebook::extract_python_source"]
+  Cak5velg3wv["cgg_lang::parser::ParserPool&lt;'r&gt;::new"]
+  Cj6zpvcbt6p["cgg_lang::parser::ParserPool&lt;'r&gt;::parse"]
+  Ctjvv5ons8i["cgg_lang::parser::ParserPool&lt;'r&gt;::plugin"]
+  C6wrijb2i8i["cgg_resolve::cross_file::resolve"]
+  Cru55mylpb0["cgg_resolve::descriptor::link_descriptors"]
+  C7sdc7dfqq8["cgg_resolve::dispatch::fanout"]
+  C1rtjt0s4z["cgg_resolve::ffi::link_ffi"]
+  Cerzjkk2e4b["cgg_resolve::frameworks::detect"]
+  Cyx4cj1kf97["cgg_resolve::intra_file::link_file"]
+  C30foz0npni["cgg_resolve::names::owner_from_qn"]
+  C13jku0363vc["cgg_resolve::type_hints::build_return_type_map"]
+  Ckhn1ppxbyv["cgg_resolve::type_hints::propagate_types_with_returns"]
+  Ct7g2skj0yq["cgg_walk::walk"]
+  Ct0c2ixgmx8 --> C12m1b7egd7a
+  C12m1b7egd7a --> Cgbax03cjph
+  C12m1b7egd7a --> Ci4p2rb43rp
+  C12m1b7egd7a --> Chj8h5ziozb
+  C12m1b7egd7a --> C2f1t66864d
+  C12m1b7egd7a --> Ctfmoqi85tg
+  C12m1b7egd7a -->|2x| Cpbf1nw0gl7
+  C12m1b7egd7a --> Ck4ptx27z7x
+  C12m1b7egd7a --> Clwcttx5lpo
+  C12m1b7egd7a --> Coix60lhqf7
+  C12m1b7egd7a --> Cwqkqak75tl
+  C12m1b7egd7a --> Clv6vms0oi1
+  C12m1b7egd7a --> C405rboiqlv
+  C12m1b7egd7a --> C1415sed6gsk
+  Cj6zpvcbt6p --> Cj6zpvcbt6p
+  C12m1b7egd7a --> Crtsepedphw
+  C12m1b7egd7a --> Cd1xvlrrdww
+  C12m1b7egd7a --> Cods529o10n
+  C12m1b7egd7a --> Ccyvdjxcoox
+  C12m1b7egd7a --> Ct7g2skj0yq
+  C12m1b7egd7a --> C12pncd15md4
+  C12m1b7egd7a --> C17o9pp22qiz
+  C12m1b7egd7a --> Cak5velg3wv
+  C12m1b7egd7a --> Cbgxp5y3jf4
+  C12m1b7egd7a --> Cf51o5g9qy0
+  C12m1b7egd7a --> C14fkc4o8c6d
+  C12m1b7egd7a --> Ciutkm7qyvn
+  C12m1b7egd7a -->|18x| Cje1i47p3yv
+  C12m1b7egd7a --> Cj6zpvcbt6p
+  C12m1b7egd7a --> Ctjvv5ons8i
+  C12m1b7egd7a --> Co7i2la9csu
+  C12m1b7egd7a --> Cka7z9fgizy
+  C12m1b7egd7a --> Cekb0n2g1eg
+  C12m1b7egd7a --> Cihr3kfyvtu
+  C12m1b7egd7a --> C30foz0npni
+  C12m1b7egd7a --> C14uv2ki067t
+  C12m1b7egd7a --> C1wzvx79ql2
+  C12m1b7egd7a --> C13jku0363vc
+  C12m1b7egd7a --> Ckhn1ppxbyv
+  C12m1b7egd7a --> Cm5zypciozo
+  C12m1b7egd7a --> Cyx4cj1kf97
+  C12m1b7egd7a --> Cbs4im1rijt
+  C12m1b7egd7a --> Cuqf7vje4v5
+  C12m1b7egd7a --> C6wrijb2i8i
+  C12m1b7egd7a --> C1rtjt0s4z
+  C12m1b7egd7a --> Cru55mylpb0
+  C12m1b7egd7a --> Cerzjkk2e4b
+  C12m1b7egd7a --> C7sdc7dfqq8
+  C12m1b7egd7a --> Ch84iv4wac8
+  C12m1b7egd7a -->|5x| C142sy5bd6bx
+  C12m1b7egd7a --> Ce8lkrr7qkj
+  C12m1b7egd7a -->|2x| Ct77oun8kqo
+  C12m1b7egd7a --> Cjqock7evo5
+  C12m1b7egd7a --> C12wdyqabzvp
+  C1415sed6gsk --> C12pncd15md4
+  C1415sed6gsk --> Ct77oun8kqo
+  C1415sed6gsk --> C142sy5bd6bx
+  C405rboiqlv --> Ct77oun8kqo
+  Ck4ptx27z7x -->|2x| Cka7z9fgizy
+  Ck4ptx27z7x -->|2x| Cihr3kfyvtu
+  Ck4ptx27z7x --> C14uv2ki067t
+  Ck4ptx27z7x --> C1wzvx79ql2
+  Ck4ptx27z7x --> Ch84iv4wac8
+  Clwcttx5lpo --> Cka7z9fgizy
+  Clwcttx5lpo --> Cihr3kfyvtu
+  Clwcttx5lpo --> C14uv2ki067t
+  Clwcttx5lpo --> C1wzvx79ql2
+  Clwcttx5lpo --> Ch84iv4wac8
+  Cjqock7evo5 --> Cf51o5g9qy0
+  C6wrijb2i8i -->|6x| Cje1i47p3yv
+  C6wrijb2i8i -->|4x| C30foz0npni
+  Cru55mylpb0 -->|2x| C30foz0npni
+  C7sdc7dfqq8 --> C30foz0npni
+  Cerzjkk2e4b -->|9x| Cje1i47p3yv
+  Cyx4cj1kf97 -->|3x| C30foz0npni
 ```
 <!-- cgg:end:self -->
 
@@ -663,81 +663,81 @@ cgg ./crates --filter 'cgg_resolve::' -n 1 -t mermaid  # resolution pipeline
 <!-- cgg:begin:walk -->
 ```mermaid
 flowchart LR
-  Cy82uv2i7pt["cgg_walk::WalkOutcome::is_empty"]
-  C580x6lp8ln["cgg_walk::<WalkConfig as Default>::default"]
-  Chco17z7ulm["cgg_walk::walk"]
-  Cbkodel2lnl["cgg_walk::walk_one"]
-  Club8n6rzww["cgg_walk::push_candidate"]
-  Ctqopiot1ae["cgg_walk::is_symlink_chain"]
-  C81nu0l348l["cgg_walk::classify_file"]
-  Cndv7fvb5ip["cgg_walk::is_binary"]
-  C5fpczbb5j6["cgg_walk::builtin_reason"]
-  C1xss5nwfte["cgg_walk::extract_err_path"]
-  C1xss5nwfte -->|2x| C1xss5nwfte
-  C81nu0l348l --> Cndv7fvb5ip
-  Cbkodel2lnl --> C1xss5nwfte
-  Cbkodel2lnl -->|2x| C5fpczbb5j6
-  Cbkodel2lnl -->|2x| C81nu0l348l
-  Cbkodel2lnl -->|2x| Club8n6rzww
-  Cbkodel2lnl --> Ctqopiot1ae
-  Chco17z7ulm --> Cbkodel2lnl
+  C15d893y4ggk["cgg_walk::WalkOutcome::is_empty"]
+  Cceyqp4l98e["cgg_walk::<WalkConfig as Default>::default"]
+  Ct7g2skj0yq["cgg_walk::walk"]
+  Cjzicnt94o7["cgg_walk::walk_one"]
+  Ccotmelqbjo["cgg_walk::push_candidate"]
+  C8qg0fse73b["cgg_walk::is_symlink_chain"]
+  Cke21cnod0["cgg_walk::classify_file"]
+  Cm1a2tmtal0["cgg_walk::is_binary"]
+  C161gaoojfoa["cgg_walk::builtin_reason"]
+  Cinxt6zar3w["cgg_walk::extract_err_path"]
+  Cinxt6zar3w -->|2x| Cinxt6zar3w
+  Cjzicnt94o7 -->|2x| C161gaoojfoa
+  Cjzicnt94o7 --> C8qg0fse73b
+  Cjzicnt94o7 -->|2x| Ccotmelqbjo
+  Cjzicnt94o7 --> Cinxt6zar3w
+  Cjzicnt94o7 -->|2x| Cke21cnod0
+  Cke21cnod0 --> Cm1a2tmtal0
+  Ct7g2skj0yq --> Cjzicnt94o7
 ```
 <!-- cgg:end:walk -->
 
 <!-- cgg:begin:lang -->
 ```mermaid
 flowchart LR
-  C10q0avqswp9["cgg_lang::detect::LanguageDetector<'r>::new"]
-  Cp7bq4qiwgz["cgg_lang::detect::LanguageDetector<'r>::detect"]
-  Cxmrendufgz["cgg_lang::detect::LanguageDetector<'r>::match_ext"]
-  C133lfcajtac["cgg_lang::detect::extension"]
-  Ck8bvt2vgvc["cgg_lang::detect::sniff_structured_descriptor"]
-  Cqwy5q5i448["cgg_lang::detect::read_shebang"]
-  Cofztst3b5["cgg_lang::detect::header_verdict"]
-  Ckwi21q4n99["cgg_lang::parser::ParserPool<'r>::new"]
-  C26bd5qoaul["cgg_lang::parser::ParserPool<'r>::parse"]
-  C6jcyyvmxks["cgg_lang::parser::ParserPool<'r>::plugin"]
-  C18c4rqxkjzb["cgg_lang::parser::set_language"]
-  Cuwydi7mhcp["cgg_lang::builtin_verbs"]
-  C10t72likkpj["cgg_lang::builtin_verbs_for"]
-  Co2908p1emo["cgg_lang::no_extra_verbs"]
-  C17j8jr3c3ba["cgg_lang::ExtractCtx<'a>::new"]
-  C59pox1dp6q["cgg_lang::ExtractCtx<'a>::for_language"]
-  C8ms88ne747["cgg_lang::ExtractCtx<'a>::plain"]
-  Cr288aq0pmb["cgg_lang::ExtractCtx<'a>::is_registrar_verb"]
-  C1wt0t8oe0q["cgg_lang::LanguagePlugin::id"]
-  C17aph71rx2h["cgg_lang::LanguagePlugin::extensions"]
-  Cjp14y8sw13["cgg_lang::LanguagePlugin::shebangs"]
-  Ct9706spgvs["cgg_lang::LanguagePlugin::signals"]
-  Cecnnkf40pw["cgg_lang::LanguagePlugin::ts_language"]
-  Ch33tzbtsjg["cgg_lang::LanguagePlugin::extract"]
-  Cjqv59ycq3v["cgg_lang::PluginRegistry::new"]
-  Cj8dfzn4rwo["cgg_lang::PluginRegistry::register"]
-  Cf0ed7vsaic["cgg_lang::PluginRegistry::all"]
-  C8gx7e4r66u["cgg_lang::PluginRegistry::by_id"]
-  Ctdg6zm99p3["cgg_lang::PluginRegistry::with_v1_plugins"]
-  C26bd5qoaul --> C18c4rqxkjzb
-  C26bd5qoaul --> C26bd5qoaul
-  C26bd5qoaul --> C8gx7e4r66u
-  C26bd5qoaul --> Cecnnkf40pw
-  C6jcyyvmxks --> C8gx7e4r66u
-  C8gx7e4r66u --> C1wt0t8oe0q
-  C8ms88ne747 --> Co2908p1emo
-  Ch33tzbtsjg --> C1wt0t8oe0q
-  Cp7bq4qiwgz -->|2x| C133lfcajtac
-  Cp7bq4qiwgz --> C1wt0t8oe0q
-  Cp7bq4qiwgz --> Cf0ed7vsaic
-  Cp7bq4qiwgz --> Cjp14y8sw13
-  Cp7bq4qiwgz --> Ck8bvt2vgvc
-  Cp7bq4qiwgz -->|2x| Cofztst3b5
-  Cp7bq4qiwgz --> Cqwy5q5i448
-  Cp7bq4qiwgz -->|2x| Cxmrendufgz
-  Cr288aq0pmb --> C10t72likkpj
-  Cr288aq0pmb --> Cuwydi7mhcp
-  Ctdg6zm99p3 --> Cjqv59ycq3v
-  Cxmrendufgz --> C17aph71rx2h
-  Cxmrendufgz --> C1wt0t8oe0q
-  Cxmrendufgz --> Cf0ed7vsaic
+  C17o9pp22qiz["cgg_lang::detect::LanguageDetector<'r>::new"]
+  C14fkc4o8c6d["cgg_lang::detect::LanguageDetector<'r>::detect"]
+  C133fmgqa0ig["cgg_lang::detect::LanguageDetector<'r>::match_ext"]
+  Cyk5n6gky4p["cgg_lang::detect::extension"]
+  Cs3w4t2zzda["cgg_lang::detect::sniff_structured_descriptor"]
+  C4ra9dqqcsj["cgg_lang::detect::read_shebang"]
+  C109i0ymo2bt["cgg_lang::detect::header_verdict"]
+  Cak5velg3wv["cgg_lang::parser::ParserPool<'r>::new"]
+  Cj6zpvcbt6p["cgg_lang::parser::ParserPool<'r>::parse"]
+  Ctjvv5ons8i["cgg_lang::parser::ParserPool<'r>::plugin"]
+  C6hax050sg0["cgg_lang::parser::set_language"]
+  C9i276bxo3n["cgg_lang::builtin_verbs"]
+  Chpw3r2gts9["cgg_lang::builtin_verbs_for"]
+  C30gzof7bc0["cgg_lang::no_extra_verbs"]
+  Cw0jatt8a82["cgg_lang::ExtractCtx<'a>::new"]
+  Co7i2la9csu["cgg_lang::ExtractCtx<'a>::for_language"]
+  C9cyfic4q7s["cgg_lang::ExtractCtx<'a>::plain"]
+  Ccpyfq2jkpd["cgg_lang::ExtractCtx<'a>::is_registrar_verb"]
+  Cr6qlg7sre4["cgg_lang::LanguagePlugin::id"]
+  Cpwl90qfu9f["cgg_lang::LanguagePlugin::extensions"]
+  Cs3ropm27dg["cgg_lang::LanguagePlugin::shebangs"]
+  Cwizekxteri["cgg_lang::LanguagePlugin::signals"]
+  Ci8pmp2tu5w["cgg_lang::LanguagePlugin::ts_language"]
+  C11riegp64ff["cgg_lang::LanguagePlugin::extract"]
+  C11d8fa2r1kn["cgg_lang::PluginRegistry::new"]
+  Cad4eijvm3n["cgg_lang::PluginRegistry::register"]
+  Cn0f1wnqwey["cgg_lang::PluginRegistry::all"]
+  C57n6e1aly["cgg_lang::PluginRegistry::by_id"]
+  C12pncd15md4["cgg_lang::PluginRegistry::with_v1_plugins"]
+  C11riegp64ff --> Cr6qlg7sre4
+  C12pncd15md4 --> C11d8fa2r1kn
+  C133fmgqa0ig --> Cn0f1wnqwey
+  C133fmgqa0ig --> Cpwl90qfu9f
+  C133fmgqa0ig --> Cr6qlg7sre4
+  C14fkc4o8c6d -->|2x| C109i0ymo2bt
+  C14fkc4o8c6d -->|2x| C133fmgqa0ig
+  C14fkc4o8c6d --> C4ra9dqqcsj
+  C14fkc4o8c6d --> Cn0f1wnqwey
+  C14fkc4o8c6d --> Cr6qlg7sre4
+  C14fkc4o8c6d --> Cs3ropm27dg
+  C14fkc4o8c6d --> Cs3w4t2zzda
+  C14fkc4o8c6d -->|2x| Cyk5n6gky4p
+  C57n6e1aly --> Cr6qlg7sre4
+  C9cyfic4q7s --> C30gzof7bc0
+  Ccpyfq2jkpd --> C9i276bxo3n
+  Ccpyfq2jkpd --> Chpw3r2gts9
+  Cj6zpvcbt6p --> C57n6e1aly
+  Cj6zpvcbt6p --> C6hax050sg0
+  Cj6zpvcbt6p --> Ci8pmp2tu5w
+  Cj6zpvcbt6p --> Cj6zpvcbt6p
+  Ctjvv5ons8i --> C57n6e1aly
 ```
 <!-- cgg:end:lang -->
 
@@ -821,11 +821,11 @@ entering the tree — the mirror image of the exit nodes
 %% in your source; they represent control entering from a framework.
 %% BEST EFFORT — see the coverage table for what cgg did and did not recognise.
 flowchart LR
-  C0["&lt;framework-entry&gt;::network::flask::route('/users') ⟨framework entry callback⟩"]
-  C1["svc.list_users"]
-  C2["svc._render"]
-  C0 -->|entry| C1
-  C1 --> C2
+  C8tjm5nd42p["&lt;framework-entry&gt;::network::flask::route('/users') ⟨framework entry callback⟩"]
+  Cq3rc7yk1ma["svc.list_users"]
+  C1e0h9zwbxof["svc._render"]
+  C8tjm5nd42p -->|entry| Cq3rc7yk1ma
+  Cq3rc7yk1ma --> C1e0h9zwbxof
 ```
 
 **On by default**, unlike the exit-node flags. The asymmetry is

--- a/README.md
+++ b/README.md
@@ -510,7 +510,7 @@ through the Python plugin (`!`, `%`, `?` magics stripped automatically).
 
 ## Self-analysis
 
-`cgg` run on its own source <!-- cgg:begin:self-stats -->(2069 callables, 4914 edges, 1770 cross-file, 127ms)<!-- cgg:end:self-stats -->. This is the 1-hop neighborhood of `cgg::analyze_in_pool`, the pipeline <!-- markdownlint-disable-line MD013 -->
+`cgg` run on its own source <!-- cgg:begin:self-stats -->(2088 callables, 4963 edges, 1785 cross-file, 119ms)<!-- cgg:end:self-stats -->. This is the 1-hop neighborhood of `cgg::analyze_in_pool`, the pipeline <!-- markdownlint-disable-line MD013 -->
 body — every edge is a real cross-crate function call, and the fan-out is
 the resolver ordering described under [How it works](#how-it-works):
 
@@ -521,119 +521,135 @@ cgg ./crates -t mermaid --filter 'cgg::analyze_in_pool$' -n 1
 <!-- cgg:begin:self -->
 ```mermaid
 flowchart LR
-  C7["cgg::deadcode::config::DeadCodeConfigFile::load"]
-  C9["cgg::deadcode::config::DeadCodeConfigFile::discover_for"]
-  C48["cgg::analyze"]
-  C49["cgg::analyze_in_pool"]
-  C50["cgg::langs_enabled"]
-  C51["cgg::specific"]
-  C52["cgg::dead_code_analysis"]
-  C56["cgg::why_live_proofs"]
-  C57["cgg::since_seeds"]
-  C58["cgg::count_lines"]
-  C59["cgg::read_file"]
-  C60["cgg::variant_to_kind"]
-  C62["cgg::synthesize_exit_nodes"]
-  C63["cgg::synthesize_entry_nodes"]
-  C64["cgg::trait_impl_target_from_qn"]
-  C65["cgg::dedup_edges"]
-  C67["cgg::group_unresolved_by_module"]
-  C73["cgg::options::RunOptions::dead_mode"]
-  C75["cgg::outcome::Emission::line"]
-  C76["cgg::outcome::Emission::always"]
-  C79["cgg::query::apply_query"]
-  C80["cgg::query::apply_exclusions"]
-  C101["cgg::since::resolve_since"]
-  C394["cgg_core::external::FileAliases::from_facts"]
-  C395["cgg_core::external::classify_external"]
-  C398["cgg_core::external::build_known_names"]
-  C459["cgg_core::graph::Graph::new"]
-  C460["cgg_core::graph::Graph::add_callable"]
-  C461["cgg_core::graph::Graph::add_file"]
-  C462["cgg_core::graph::Graph::add_edge"]
-  C480["cgg_core::profile::enable"]
-  C483["cgg_core::profile::span"]
-  C491["cgg_core::testfile::classify_test_file"]
-  C562["cgg_lang::detect::LanguageDetector&lt;'r&gt;::new"]
-  C563["cgg_lang::detect::LanguageDetector&lt;'r&gt;::detect"]
-  C585["cgg_lang::ExtractCtx&lt;'a&gt;::for_language"]
-  C598["cgg_lang::PluginRegistry::with_v1_plugins"]
-  C603["cgg_lang::notebook::extract_python_source"]
-  C609["cgg_lang::parser::ParserPool&lt;'r&gt;::new"]
-  C610["cgg_lang::parser::ParserPool&lt;'r&gt;::parse"]
-  C611["cgg_lang::parser::ParserPool&lt;'r&gt;::plugin"]
-  C1746["cgg_resolve::cross_file::resolve"]
-  C1882["cgg_resolve::descriptor::link_descriptors"]
-  C1889["cgg_resolve::dispatch::fanout"]
-  C1893["cgg_resolve::ffi::link_ffi"]
-  C1909["cgg_resolve::frameworks::detect"]
-  C1972["cgg_resolve::intra_file::link_file"]
-  C2016["cgg_resolve::type_hints::build_return_type_map"]
-  C2017["cgg_resolve::type_hints::propagate_types_with_returns"]
-  C2035["cgg_walk::walk"]
-  C48 --> C49
-  C49 --> C50
-  C49 --> C59
-  C49 --> C58
-  C49 --> C60
-  C49 --> C64
-  C49 -->|2x| C51
-  C49 --> C62
-  C49 --> C63
-  C49 --> C67
-  C49 --> C65
-  C49 --> C57
-  C49 --> C56
-  C49 --> C52
-  C610 --> C610
-  C49 --> C73
-  C49 --> C9
-  C49 --> C7
-  C49 --> C480
-  C49 --> C2035
-  C49 --> C598
-  C49 --> C562
-  C49 --> C609
-  C49 --> C459
-  C49 --> C563
-  C49 --> C603
-  C49 -->|18x| C483
-  C49 --> C610
-  C49 --> C611
-  C49 --> C585
-  C49 --> C491
-  C49 --> C461
-  C49 --> C460
-  C49 --> C2016
-  C49 --> C2017
-  C49 --> C398
-  C49 --> C1972
-  C49 --> C394
-  C49 --> C395
-  C49 --> C1746
-  C49 --> C1893
-  C49 --> C1882
-  C49 --> C1909
-  C49 --> C1889
-  C49 --> C462
-  C49 -->|5x| C75
-  C49 --> C101
-  C49 -->|2x| C76
-  C49 --> C79
-  C49 --> C80
-  C52 --> C598
-  C52 --> C76
-  C52 --> C75
-  C56 --> C76
-  C62 -->|2x| C461
-  C62 --> C460
-  C62 --> C462
-  C63 --> C461
-  C63 --> C460
-  C63 --> C462
-  C79 --> C459
-  C1746 -->|6x| C483
-  C1909 -->|9x| C483
+  Ce8btaz0c7d["cgg::deadcode::config::DeadCodeConfigFile::load"]
+  C1fuqoee162["cgg::deadcode::config::DeadCodeConfigFile::discover_for"]
+  Cu8sm37x27i["cgg::analyze"]
+  Ck6rdns31fh["cgg::analyze_in_pool"]
+  Cisqfzflkw2["cgg::langs_enabled"]
+  C7vl7hj6da0["cgg::specific"]
+  Cc6430xzlhv["cgg::dead_code_analysis"]
+  Cyb8lff0cu6["cgg::why_live_proofs"]
+  Crazkm27b4n["cgg::since_seeds"]
+  Ce6100aa7pb["cgg::count_lines"]
+  Cd2jp9c8iji["cgg::read_file"]
+  C4uh9t2boar["cgg::variant_to_kind"]
+  Cyuotlqx8cg["cgg::synthesize_exit_nodes"]
+  C14txnctguqp["cgg::synthesize_entry_nodes"]
+  C110r2j3hgh3["cgg::trait_impl_target_from_qn"]
+  C12cl5iiregd["cgg::dedup_edges"]
+  Coz7jqry0jt["cgg::group_unresolved_by_module"]
+  Civon2m7kiq["cgg::options::RunOptions::dead_mode"]
+  Cpdmf2f970w["cgg::outcome::Emission::line"]
+  Co9lkohbv7["cgg::outcome::Emission::always"]
+  Cikry60zwgd["cgg::query::apply_query"]
+  Cegjh02oqxa["cgg::query::apply_exclusions"]
+  Cjn5qmo68zf["cgg::since::resolve_since"]
+  Cjwpbtnrpq9["cgg::stable_ids::StableIds::new"]
+  Cr37f9vwja4["cgg::stable_ids::StableIds::file"]
+  C7x7z80po60["cgg::stable_ids::StableIds::callable"]
+  C9dybi363du["cgg_core::external::FileAliases::from_facts"]
+  Cr8fsp2a2yv["cgg_core::external::classify_external"]
+  C1763zjuiemp["cgg_core::external::build_known_names"]
+  C7b3b3l1lm6["cgg_core::graph::Graph::new"]
+  Cuqpquw4s0d["cgg_core::graph::Graph::add_callable"]
+  C11hq6v37tdw["cgg_core::graph::Graph::add_file"]
+  Cns9jydj0k1["cgg_core::graph::Graph::add_edge"]
+  Cl392qv0r5a["cgg_core::profile::enable"]
+  Chptg76umzv["cgg_core::profile::span"]
+  C2lsittm2s4["cgg_core::testfile::classify_test_file"]
+  C10q0avqswp9["cgg_lang::detect::LanguageDetector&lt;'r&gt;::new"]
+  Cp7bq4qiwgz["cgg_lang::detect::LanguageDetector&lt;'r&gt;::detect"]
+  C59pox1dp6q["cgg_lang::ExtractCtx&lt;'a&gt;::for_language"]
+  Ctdg6zm99p3["cgg_lang::PluginRegistry::with_v1_plugins"]
+  C184und02q38["cgg_lang::notebook::extract_python_source"]
+  Ckwi21q4n99["cgg_lang::parser::ParserPool&lt;'r&gt;::new"]
+  C26bd5qoaul["cgg_lang::parser::ParserPool&lt;'r&gt;::parse"]
+  C6jcyyvmxks["cgg_lang::parser::ParserPool&lt;'r&gt;::plugin"]
+  C14crdads27m["cgg_resolve::cross_file::resolve"]
+  Cf3d62vvukt["cgg_resolve::descriptor::link_descriptors"]
+  Cbuowmgsuna["cgg_resolve::dispatch::fanout"]
+  C92h1zyobno["cgg_resolve::ffi::link_ffi"]
+  Cm7bu22jhwg["cgg_resolve::frameworks::detect"]
+  Ckwpvjofrwg["cgg_resolve::intra_file::link_file"]
+  C92stn8ydvj["cgg_resolve::names::owner_from_qn"]
+  C83eo6qi9sg["cgg_resolve::type_hints::build_return_type_map"]
+  C652z8l1h5w["cgg_resolve::type_hints::propagate_types_with_returns"]
+  Chco17z7ulm["cgg_walk::walk"]
+  Cu8sm37x27i --> Ck6rdns31fh
+  Ck6rdns31fh --> Cisqfzflkw2
+  Ck6rdns31fh --> Cd2jp9c8iji
+  Ck6rdns31fh --> Ce6100aa7pb
+  Ck6rdns31fh --> C4uh9t2boar
+  Ck6rdns31fh --> C110r2j3hgh3
+  Ck6rdns31fh -->|2x| C7vl7hj6da0
+  Ck6rdns31fh --> Cyuotlqx8cg
+  Ck6rdns31fh --> C14txnctguqp
+  Ck6rdns31fh --> Coz7jqry0jt
+  Ck6rdns31fh --> C12cl5iiregd
+  Ck6rdns31fh --> Crazkm27b4n
+  Ck6rdns31fh --> Cyb8lff0cu6
+  Ck6rdns31fh --> Cc6430xzlhv
+  C26bd5qoaul --> C26bd5qoaul
+  Ck6rdns31fh --> Civon2m7kiq
+  Ck6rdns31fh --> C1fuqoee162
+  Ck6rdns31fh --> Ce8btaz0c7d
+  Ck6rdns31fh --> Cl392qv0r5a
+  Ck6rdns31fh --> Chco17z7ulm
+  Ck6rdns31fh --> Ctdg6zm99p3
+  Ck6rdns31fh --> C10q0avqswp9
+  Ck6rdns31fh --> Ckwi21q4n99
+  Ck6rdns31fh --> Cjwpbtnrpq9
+  Ck6rdns31fh --> C7b3b3l1lm6
+  Ck6rdns31fh --> Cp7bq4qiwgz
+  Ck6rdns31fh --> C184und02q38
+  Ck6rdns31fh -->|18x| Chptg76umzv
+  Ck6rdns31fh --> C26bd5qoaul
+  Ck6rdns31fh --> C6jcyyvmxks
+  Ck6rdns31fh --> C59pox1dp6q
+  Ck6rdns31fh --> Cr37f9vwja4
+  Ck6rdns31fh --> C2lsittm2s4
+  Ck6rdns31fh --> C11hq6v37tdw
+  Ck6rdns31fh --> C92stn8ydvj
+  Ck6rdns31fh --> C7x7z80po60
+  Ck6rdns31fh --> Cuqpquw4s0d
+  Ck6rdns31fh --> C83eo6qi9sg
+  Ck6rdns31fh --> C652z8l1h5w
+  Ck6rdns31fh --> C1763zjuiemp
+  Ck6rdns31fh --> Ckwpvjofrwg
+  Ck6rdns31fh --> C9dybi363du
+  Ck6rdns31fh --> Cr8fsp2a2yv
+  Ck6rdns31fh --> C14crdads27m
+  Ck6rdns31fh --> C92h1zyobno
+  Ck6rdns31fh --> Cf3d62vvukt
+  Ck6rdns31fh --> Cm7bu22jhwg
+  Ck6rdns31fh --> Cbuowmgsuna
+  Ck6rdns31fh --> Cns9jydj0k1
+  Ck6rdns31fh -->|5x| Cpdmf2f970w
+  Ck6rdns31fh --> Cjn5qmo68zf
+  Ck6rdns31fh -->|2x| Co9lkohbv7
+  Ck6rdns31fh --> Cikry60zwgd
+  Ck6rdns31fh --> Cegjh02oqxa
+  Cc6430xzlhv --> Ctdg6zm99p3
+  Cc6430xzlhv --> Co9lkohbv7
+  Cc6430xzlhv --> Cpdmf2f970w
+  Cyb8lff0cu6 --> Co9lkohbv7
+  Cyuotlqx8cg -->|2x| Cr37f9vwja4
+  Cyuotlqx8cg -->|2x| C11hq6v37tdw
+  Cyuotlqx8cg --> C7x7z80po60
+  Cyuotlqx8cg --> Cuqpquw4s0d
+  Cyuotlqx8cg --> Cns9jydj0k1
+  C14txnctguqp --> Cr37f9vwja4
+  C14txnctguqp --> C11hq6v37tdw
+  C14txnctguqp --> C7x7z80po60
+  C14txnctguqp --> Cuqpquw4s0d
+  C14txnctguqp --> Cns9jydj0k1
+  Cikry60zwgd --> C7b3b3l1lm6
+  C14crdads27m -->|6x| Chptg76umzv
+  C14crdads27m -->|4x| C92stn8ydvj
+  Cf3d62vvukt -->|2x| C92stn8ydvj
+  Cbuowmgsuna --> C92stn8ydvj
+  Cm7bu22jhwg -->|9x| Chptg76umzv
+  Ckwpvjofrwg -->|3x| C92stn8ydvj
 ```
 <!-- cgg:end:self -->
 
@@ -647,81 +663,81 @@ cgg ./crates --filter 'cgg_resolve::' -n 1 -t mermaid  # resolution pipeline
 <!-- cgg:begin:walk -->
 ```mermaid
 flowchart LR
-  C0["cgg_walk::WalkOutcome::is_empty"]
-  C1["cgg_walk::<WalkConfig as Default>::default"]
-  C2["cgg_walk::walk"]
-  C3["cgg_walk::walk_one"]
-  C4["cgg_walk::push_candidate"]
-  C5["cgg_walk::is_symlink_chain"]
-  C6["cgg_walk::classify_file"]
-  C7["cgg_walk::is_binary"]
-  C8["cgg_walk::builtin_reason"]
-  C9["cgg_walk::extract_err_path"]
-  C2 --> C3
-  C3 -->|2x| C4
-  C3 --> C5
-  C3 -->|2x| C6
-  C3 -->|2x| C8
-  C3 --> C9
-  C6 --> C7
-  C9 -->|2x| C9
+  Cy82uv2i7pt["cgg_walk::WalkOutcome::is_empty"]
+  C580x6lp8ln["cgg_walk::<WalkConfig as Default>::default"]
+  Chco17z7ulm["cgg_walk::walk"]
+  Cbkodel2lnl["cgg_walk::walk_one"]
+  Club8n6rzww["cgg_walk::push_candidate"]
+  Ctqopiot1ae["cgg_walk::is_symlink_chain"]
+  C81nu0l348l["cgg_walk::classify_file"]
+  Cndv7fvb5ip["cgg_walk::is_binary"]
+  C5fpczbb5j6["cgg_walk::builtin_reason"]
+  C1xss5nwfte["cgg_walk::extract_err_path"]
+  C1xss5nwfte -->|2x| C1xss5nwfte
+  C81nu0l348l --> Cndv7fvb5ip
+  Cbkodel2lnl --> C1xss5nwfte
+  Cbkodel2lnl -->|2x| C5fpczbb5j6
+  Cbkodel2lnl -->|2x| C81nu0l348l
+  Cbkodel2lnl -->|2x| Club8n6rzww
+  Cbkodel2lnl --> Ctqopiot1ae
+  Chco17z7ulm --> Cbkodel2lnl
 ```
 <!-- cgg:end:walk -->
 
 <!-- cgg:begin:lang -->
 ```mermaid
 flowchart LR
-  C0["cgg_lang::detect::LanguageDetector<'r>::new"]
-  C1["cgg_lang::detect::LanguageDetector<'r>::detect"]
-  C2["cgg_lang::detect::LanguageDetector<'r>::match_ext"]
-  C3["cgg_lang::detect::extension"]
-  C4["cgg_lang::detect::sniff_structured_descriptor"]
-  C5["cgg_lang::detect::read_shebang"]
-  C6["cgg_lang::detect::header_verdict"]
-  C19["cgg_lang::parser::ParserPool<'r>::new"]
-  C20["cgg_lang::parser::ParserPool<'r>::parse"]
-  C21["cgg_lang::parser::ParserPool<'r>::plugin"]
-  C22["cgg_lang::parser::set_language"]
-  C26["cgg_lang::builtin_verbs"]
-  C27["cgg_lang::builtin_verbs_for"]
-  C28["cgg_lang::no_extra_verbs"]
-  C29["cgg_lang::ExtractCtx<'a>::new"]
-  C30["cgg_lang::ExtractCtx<'a>::for_language"]
-  C31["cgg_lang::ExtractCtx<'a>::plain"]
-  C32["cgg_lang::ExtractCtx<'a>::is_registrar_verb"]
-  C33["cgg_lang::LanguagePlugin::id"]
-  C34["cgg_lang::LanguagePlugin::extensions"]
-  C35["cgg_lang::LanguagePlugin::shebangs"]
-  C36["cgg_lang::LanguagePlugin::signals"]
-  C37["cgg_lang::LanguagePlugin::ts_language"]
-  C38["cgg_lang::LanguagePlugin::extract"]
-  C39["cgg_lang::PluginRegistry::new"]
-  C40["cgg_lang::PluginRegistry::register"]
-  C41["cgg_lang::PluginRegistry::all"]
-  C42["cgg_lang::PluginRegistry::by_id"]
-  C43["cgg_lang::PluginRegistry::with_v1_plugins"]
-  C1 -->|2x| C2
-  C1 -->|2x| C3
-  C1 --> C33
-  C1 --> C35
-  C1 --> C4
-  C1 --> C41
-  C1 --> C5
-  C1 -->|2x| C6
-  C2 --> C33
-  C2 --> C34
-  C2 --> C41
-  C20 --> C20
-  C20 --> C22
-  C20 --> C37
-  C20 --> C42
-  C21 --> C42
-  C31 --> C28
-  C32 --> C26
-  C32 --> C27
-  C38 --> C33
-  C42 --> C33
-  C43 --> C39
+  C10q0avqswp9["cgg_lang::detect::LanguageDetector<'r>::new"]
+  Cp7bq4qiwgz["cgg_lang::detect::LanguageDetector<'r>::detect"]
+  Cxmrendufgz["cgg_lang::detect::LanguageDetector<'r>::match_ext"]
+  C133lfcajtac["cgg_lang::detect::extension"]
+  Ck8bvt2vgvc["cgg_lang::detect::sniff_structured_descriptor"]
+  Cqwy5q5i448["cgg_lang::detect::read_shebang"]
+  Cofztst3b5["cgg_lang::detect::header_verdict"]
+  Ckwi21q4n99["cgg_lang::parser::ParserPool<'r>::new"]
+  C26bd5qoaul["cgg_lang::parser::ParserPool<'r>::parse"]
+  C6jcyyvmxks["cgg_lang::parser::ParserPool<'r>::plugin"]
+  C18c4rqxkjzb["cgg_lang::parser::set_language"]
+  Cuwydi7mhcp["cgg_lang::builtin_verbs"]
+  C10t72likkpj["cgg_lang::builtin_verbs_for"]
+  Co2908p1emo["cgg_lang::no_extra_verbs"]
+  C17j8jr3c3ba["cgg_lang::ExtractCtx<'a>::new"]
+  C59pox1dp6q["cgg_lang::ExtractCtx<'a>::for_language"]
+  C8ms88ne747["cgg_lang::ExtractCtx<'a>::plain"]
+  Cr288aq0pmb["cgg_lang::ExtractCtx<'a>::is_registrar_verb"]
+  C1wt0t8oe0q["cgg_lang::LanguagePlugin::id"]
+  C17aph71rx2h["cgg_lang::LanguagePlugin::extensions"]
+  Cjp14y8sw13["cgg_lang::LanguagePlugin::shebangs"]
+  Ct9706spgvs["cgg_lang::LanguagePlugin::signals"]
+  Cecnnkf40pw["cgg_lang::LanguagePlugin::ts_language"]
+  Ch33tzbtsjg["cgg_lang::LanguagePlugin::extract"]
+  Cjqv59ycq3v["cgg_lang::PluginRegistry::new"]
+  Cj8dfzn4rwo["cgg_lang::PluginRegistry::register"]
+  Cf0ed7vsaic["cgg_lang::PluginRegistry::all"]
+  C8gx7e4r66u["cgg_lang::PluginRegistry::by_id"]
+  Ctdg6zm99p3["cgg_lang::PluginRegistry::with_v1_plugins"]
+  C26bd5qoaul --> C18c4rqxkjzb
+  C26bd5qoaul --> C26bd5qoaul
+  C26bd5qoaul --> C8gx7e4r66u
+  C26bd5qoaul --> Cecnnkf40pw
+  C6jcyyvmxks --> C8gx7e4r66u
+  C8gx7e4r66u --> C1wt0t8oe0q
+  C8ms88ne747 --> Co2908p1emo
+  Ch33tzbtsjg --> C1wt0t8oe0q
+  Cp7bq4qiwgz -->|2x| C133lfcajtac
+  Cp7bq4qiwgz --> C1wt0t8oe0q
+  Cp7bq4qiwgz --> Cf0ed7vsaic
+  Cp7bq4qiwgz --> Cjp14y8sw13
+  Cp7bq4qiwgz --> Ck8bvt2vgvc
+  Cp7bq4qiwgz -->|2x| Cofztst3b5
+  Cp7bq4qiwgz --> Cqwy5q5i448
+  Cp7bq4qiwgz -->|2x| Cxmrendufgz
+  Cr288aq0pmb --> C10t72likkpj
+  Cr288aq0pmb --> Cuwydi7mhcp
+  Ctdg6zm99p3 --> Cjqv59ycq3v
+  Cxmrendufgz --> C17aph71rx2h
+  Cxmrendufgz --> C1wt0t8oe0q
+  Cxmrendufgz --> Cf0ed7vsaic
 ```
 <!-- cgg:end:lang -->
 

--- a/crates/cgg-core/src/audit.rs
+++ b/crates/cgg-core/src/audit.rs
@@ -715,7 +715,7 @@ mod tests {
         assert_eq!(c2.candidates.file_local, 3);
 
         // Legacy free-form string form still parses.
-        let legacy = r#"{"src":null,"file":0,"site_line":1,"site_byte":2,"name":"m","reason":"ambiguous-in-file"}"#;
+        let legacy = r#"{"src":null,"file":"F0","site_line":1,"site_byte":2,"name":"m","reason":"ambiguous-in-file"}"#;
         let c3: AuditUnresolvedCall = serde_json::from_str(legacy).unwrap();
         assert_eq!(c3.reason, UnresolvedReason::AmbiguousInFile);
     }

--- a/crates/cgg-core/src/cpu.rs
+++ b/crates/cgg-core/src/cpu.rs
@@ -26,6 +26,7 @@
 //! otherwise CI inside a small container would spawn 16 workers for 4
 //! CPUs and thrash.
 
+#[cfg(target_os = "linux")]
 use std::collections::HashSet;
 
 /// Physical cores usable by this process.

--- a/crates/cgg-core/src/ids.rs
+++ b/crates/cgg-core/src/ids.rs
@@ -1,38 +1,97 @@
 //! Strongly-typed identifiers for graph entities.
 //!
-//! Every `Id` type is a transparent wrapper over `u32` so the graph
-//! stays compact in memory while the type system prevents mixing a
+//! Every `Id` type is a transparent wrapper over `u64` so it can hold a
+//! content-derived hash (see `StableIds` in the `cgg` crate) rather than
+//! a sequential per-run counter. A hash-derived id is stable across runs
+//! that add or remove unrelated nodes — the whole point of moving off
+//! sequential integers — while the type system still prevents mixing a
 //! callable id with a file id.
+//!
+//! On the wire (JSON, mermaid, dot, graphml) an id is rendered as its
+//! type prefix followed by the base36 encoding of the inner value
+//! (`"C4k2j9qh3xz"`), not a decimal number — base36 keeps a 52-bit hash
+//! to about 10 characters instead of 16, and the non-numeric wire form is
+//! a visible reminder that these are not sequential indices to diff
+//! across runs.
 
-use serde::{Deserialize, Serialize};
+use serde::de::Error as _;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::fmt;
+use std::str::FromStr;
+
+const BASE36_ALPHABET: &[u8; 36] = b"0123456789abcdefghijklmnopqrstuvwxyz";
+
+/// Encode `v` as lowercase base36 (alphabet `0-9a-z`), no leading-zero
+/// padding — matches how `u64::to_string()` has no padding in base10.
+pub fn to_base36(mut v: u64) -> String {
+    if v == 0 {
+        return "0".to_string();
+    }
+    let mut digits = Vec::with_capacity(13); // ceil(log36(u64::MAX)) = 13
+    while v > 0 {
+        digits.push(BASE36_ALPHABET[(v % 36) as usize]);
+        v /= 36;
+    }
+    digits.reverse();
+    // SAFETY: every byte pushed above comes from BASE36_ALPHABET, which is
+    // ASCII.
+    String::from_utf8(digits).expect("base36 digits are always valid UTF-8")
+}
+
+/// Decode a lowercase (or uppercase) base36 string back into a `u64`.
+/// Returns `None` on an empty string or a non-base36 character.
+pub fn from_base36(s: &str) -> Option<u64> {
+    if s.is_empty() {
+        return None;
+    }
+    let mut v: u64 = 0;
+    for c in s.chars() {
+        let digit = c.to_digit(36)?;
+        v = v.checked_mul(36)?.checked_add(digit as u64)?;
+    }
+    Some(v)
+}
+
+/// Error returned by `FromStr` for an id type: the string was missing
+/// the type's prefix character, or what followed it was not base36.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IdParseError(pub String);
+
+impl fmt::Display for IdParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "invalid id string: {:?}", self.0)
+    }
+}
+
+impl std::error::Error for IdParseError {}
 
 macro_rules! id_type {
     ($name:ident, $prefix:literal) => {
-        #[derive(
-            Copy,
-            Clone,
-            Debug,
-            Default,
-            Eq,
-            PartialEq,
-            Ord,
-            PartialOrd,
-            Hash,
-            Serialize,
-            Deserialize,
-        )]
-        #[serde(transparent)]
-        pub struct $name(pub u32);
+        #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
+        pub struct $name(pub u64);
 
         impl $name {
             #[inline]
             pub const fn new(v: u32) -> Self {
-                Self(v)
+                Self(v as u64)
             }
 
             #[inline]
+            pub const fn new_u64(v: u64) -> Self {
+                Self(v)
+            }
+
+            /// Truncating u32 view of the inner value. Content-derived ids
+            /// routinely exceed 32 bits, so this loses information — it
+            /// exists for API back-compat and small hand-built test ids,
+            /// never use it as a dedup/sort key on a real analyzed graph.
+            #[inline]
             pub const fn as_u32(self) -> u32 {
+                self.0 as u32
+            }
+
+            #[inline]
+            pub const fn as_u64(self) -> u64 {
                 self.0
             }
 
@@ -40,17 +99,62 @@ macro_rules! id_type {
             pub const fn as_usize(self) -> usize {
                 self.0 as usize
             }
+
+            /// Base36 digits only, no type prefix — for formatters that
+            /// want to prepend their own node-name prefix character.
+            #[inline]
+            pub fn token(self) -> String {
+                to_base36(self.0)
+            }
         }
 
         impl fmt::Display for $name {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                write!(f, "{}{}", $prefix, self.0)
+                write!(f, "{}{}", $prefix, to_base36(self.0))
+            }
+        }
+
+        impl FromStr for $name {
+            type Err = IdParseError;
+
+            fn from_str(s: &str) -> Result<Self, Self::Err> {
+                let rest = s
+                    .strip_prefix($prefix)
+                    .ok_or_else(|| IdParseError(s.to_string()))?;
+                let v = from_base36(rest).ok_or_else(|| IdParseError(s.to_string()))?;
+                Ok(Self(v))
+            }
+        }
+
+        impl Serialize for $name {
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: Serializer,
+            {
+                serializer.serialize_str(&self.to_string())
+            }
+        }
+
+        impl<'de> Deserialize<'de> for $name {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                let s = String::deserialize(deserializer)?;
+                s.parse::<Self>().map_err(D::Error::custom)
             }
         }
 
         impl From<u32> for $name {
             #[inline]
             fn from(v: u32) -> Self {
+                Self(v as u64)
+            }
+        }
+
+        impl From<u64> for $name {
+            #[inline]
+            fn from(v: u64) -> Self {
                 Self(v)
             }
         }
@@ -97,19 +201,62 @@ mod tests {
     use super::*;
 
     #[test]
-    fn display_uses_the_type_prefix() {
+    fn base36_round_trips() {
+        for v in [0u64, 1, 35, 36, 42, 12345, u32::MAX as u64, u64::MAX] {
+            let s = to_base36(v);
+            assert!(
+                s.chars()
+                    .all(|c| c.is_ascii_digit() || c.is_ascii_lowercase()),
+                "base36 output must be lowercase alnum: {s:?}"
+            );
+            assert_eq!(from_base36(&s), Some(v));
+        }
+    }
+
+    #[test]
+    fn display_uses_the_type_prefix_and_base36() {
         // The prefix is what makes an id readable in mermaid/dot node
         // names and in the audit log, and it must differ per type.
         assert_eq!(CallableId::new(7).to_string(), "C7");
         assert_eq!(FileId::new(7).to_string(), "F7");
+        // 36 is the first value whose base36 encoding is two digits.
+        assert_eq!(CallableId::new(36).to_string(), "C10");
+        // A value that needs the full u64 range still round-trips.
+        let big = CallableId::new_u64(0x000f_ffff_ffff_ffff); // 52 bits set
+        let shown = big.to_string();
+        assert!(shown.starts_with('C'));
+        assert_eq!(shown.parse::<CallableId>().unwrap(), big);
+    }
+
+    #[test]
+    fn from_str_round_trips_and_rejects_garbage() {
+        let id = CallableId::new_u64(123_456_789);
+        let s = id.to_string();
+        assert_eq!(s.parse::<CallableId>().unwrap(), id);
+
+        // Wrong prefix.
+        assert!("F123".parse::<CallableId>().is_err());
+        // No prefix at all.
+        assert!("123".parse::<CallableId>().is_err());
+        // Non-base36 body.
+        assert!("C!!!".parse::<CallableId>().is_err());
+    }
+
+    #[test]
+    fn token_has_no_prefix() {
+        let id = CallableId::new(42);
+        assert_eq!(id.token(), to_base36(42));
+        assert!(!id.token().contains('C'));
     }
 
     #[test]
     fn accessors_round_trip() {
         let c = CallableId::new(42);
         assert_eq!(c.as_u32(), 42);
+        assert_eq!(c.as_u64(), 42u64);
         assert_eq!(c.as_usize(), 42usize);
         assert_eq!(CallableId::from(42u32), c);
+        assert_eq!(CallableId::from(42u64), c);
         assert_eq!(FileId::default(), FileId::new(0));
     }
 
@@ -124,12 +271,16 @@ mod tests {
     }
 
     #[test]
-    fn ids_serialize_transparently() {
-        // `#[serde(transparent)]` is load-bearing: the JSON format
-        // documents edges as `{"src": 0, ...}`, not `{"src": {"0": 0}}`.
-        assert_eq!(serde_json::to_string(&CallableId::new(3)).unwrap(), "3");
-        assert_eq!(serde_json::to_string(&FileId::new(4)).unwrap(), "4");
-        let back: CallableId = serde_json::from_str("3").unwrap();
+    fn ids_serialize_as_json_strings() {
+        // Ids are content-derived hashes now, not sequential indices, so
+        // the wire form is a prefixed base36 *string* rather than a bare
+        // JSON number: `{"src": "c3", ...}`, not `{"src": 3}`.
+        assert_eq!(
+            serde_json::to_string(&CallableId::new(3)).unwrap(),
+            "\"C3\""
+        );
+        assert_eq!(serde_json::to_string(&FileId::new(4)).unwrap(), "\"F4\"");
+        let back: CallableId = serde_json::from_str("\"C3\"").unwrap();
         assert_eq!(back, CallableId::new(3));
     }
 

--- a/crates/cgg-format/src/dot.rs
+++ b/crates/cgg-format/src/dot.rs
@@ -51,7 +51,7 @@ impl GraphFormatter for DotFormatter {
                     "  n{} [label=\"{}\", shape=invhouse, color=\"#aa22cc\", \
                      tooltip=\"framework entry callback ({}) — SYNTHESIZED: no call to \
                      this node exists in your source\"];",
-                    id.as_u32(),
+                    id.token(),
                     label,
                     kind.slug()
                 )?;
@@ -61,11 +61,11 @@ impl GraphFormatter for DotFormatter {
                     "  n{} [label=\"{}\", style=dashed, \
                      tooltip=\"unreferenced (best effort: cgg found no caller, \
                      which is not proof none exists)\"];",
-                    id.as_u32(),
+                    id.token(),
                     label
                 )?;
             } else {
-                writeln!(out, "  n{} [label=\"{}\"];", id.as_u32(), label)?;
+                writeln!(out, "  n{} [label=\"{}\"];", id.token(), label)?;
             }
         }
         // Collapse parallel edges (same src/dst pair, different call
@@ -73,21 +73,20 @@ impl GraphFormatter for DotFormatter {
         // first-occurrence order for deterministic, diff-friendly
         // output. JSON/GraphML still emit one entry per call site —
         // this is purely a render-time concern.
-        let mut order: Vec<(u32, u32, &str, &str)> = Vec::new();
-        let mut counts: std::collections::HashMap<(u32, u32, &str), u32> =
+        let mut order: Vec<(String, String, &str, &str)> = Vec::new();
+        let mut counts: std::collections::HashMap<(String, String, &str), u32> =
             std::collections::HashMap::new();
         for edge in &graph.edges {
             let (tag, style) = via_dot(&edge.via);
-            let key = (edge.src.as_u32(), edge.dst.as_u32(), tag);
-            if counts
-                .insert(key, counts.get(&key).copied().unwrap_or(0) + 1)
-                .is_none()
-            {
-                order.push((edge.src.as_u32(), edge.dst.as_u32(), tag, style));
+            let key = (edge.src.token(), edge.dst.token(), tag);
+            let entry = counts.entry(key.clone()).or_insert(0);
+            *entry += 1;
+            if *entry == 1 {
+                order.push((key.0, key.1, tag, style));
             }
         }
         for (src, dst, tag, style) in order {
-            let n = counts[&(src, dst, tag)];
+            let n = counts[&(src.clone(), dst.clone(), tag)];
             let label = match (tag.is_empty(), n > 1) {
                 (true, false) => String::new(),
                 (true, true) => format!("{n}x"),

--- a/crates/cgg-format/src/dot.rs
+++ b/crates/cgg-format/src/dot.rs
@@ -3,6 +3,7 @@
 use crate::{GraphFormatter, OutputFormat};
 use cgg_core::Graph;
 use cgg_core::graph::Via;
+use cgg_core::ids::CallableId;
 use std::io;
 
 /// Per-`via` DOT rendering: a short label tag and extra edge attributes
@@ -73,26 +74,29 @@ impl GraphFormatter for DotFormatter {
         // first-occurrence order for deterministic, diff-friendly
         // output. JSON/GraphML still emit one entry per call site —
         // this is purely a render-time concern.
-        let mut order: Vec<(String, String, &str, &str)> = Vec::new();
-        let mut counts: std::collections::HashMap<(String, String, &str), u32> =
+        // Keys stay `Copy`; the base36 token is rendered only at write
+        // time. See the matching note in mermaid.rs.
+        let mut order: Vec<(CallableId, CallableId, &str, &str)> = Vec::new();
+        let mut counts: std::collections::HashMap<(CallableId, CallableId, &str), u32> =
             std::collections::HashMap::new();
         for edge in &graph.edges {
             let (tag, style) = via_dot(&edge.via);
-            let key = (edge.src.token(), edge.dst.token(), tag);
-            let entry = counts.entry(key.clone()).or_insert(0);
+            let key = (edge.src, edge.dst, tag);
+            let entry = counts.entry(key).or_insert(0);
             *entry += 1;
             if *entry == 1 {
                 order.push((key.0, key.1, tag, style));
             }
         }
         for (src, dst, tag, style) in order {
-            let n = counts[&(src.clone(), dst.clone(), tag)];
+            let n = counts[&(src, dst, tag)];
             let label = match (tag.is_empty(), n > 1) {
                 (true, false) => String::new(),
                 (true, true) => format!("{n}x"),
                 (false, false) => tag.to_string(),
                 (false, true) => format!("{tag} {n}x"),
             };
+            let (src, dst) = (src.token(), dst.token());
             if label.is_empty() && style.is_empty() {
                 writeln!(out, "  n{src} -> n{dst};")?;
             } else if style.is_empty() {

--- a/crates/cgg-format/src/graphml.rs
+++ b/crates/cgg-format/src/graphml.rs
@@ -67,7 +67,7 @@ impl GraphFormatter for GraphmlFormatter {
         )?;
         writeln!(out, r#"  <graph id="G" edgedefault="directed">"#)?;
         for (id, node) in &graph.callables {
-            writeln!(out, r#"    <node id="n{}">"#, id.as_u32())?;
+            writeln!(out, r#"    <node id="n{}">"#, id.token())?;
             writeln!(
                 out,
                 r#"      <data key="label">{}</data>"#,
@@ -111,16 +111,16 @@ impl GraphFormatter for GraphmlFormatter {
                     out,
                     r#"    <edge id="e{}" source="n{}" target="n{}"/>"#,
                     i,
-                    edge.src.as_u32(),
-                    edge.dst.as_u32()
+                    edge.src.token(),
+                    edge.dst.token()
                 )?;
             } else {
                 writeln!(
                     out,
                     r#"    <edge id="e{}" source="n{}" target="n{}"><data key="via">{}</data></edge>"#,
                     i,
-                    edge.src.as_u32(),
-                    edge.dst.as_u32(),
+                    edge.src.token(),
+                    edge.dst.token(),
                     via
                 )?;
             }

--- a/crates/cgg-format/src/mermaid.rs
+++ b/crates/cgg-format/src/mermaid.rs
@@ -103,7 +103,7 @@ impl GraphFormatter for MermaidFormatter {
             } else {
                 ""
             };
-            writeln!(out, "  C{id_n}[\"{label}{tag}\"]", id_n = id.as_u32())?;
+            writeln!(out, "  C{id_n}[\"{label}{tag}\"]", id_n = id.token())?;
         }
         if any_unreferenced {
             writeln!(out, "  classDef unreferenced stroke-dasharray: 4 3;")?;
@@ -111,7 +111,7 @@ impl GraphFormatter for MermaidFormatter {
                 .callables
                 .iter()
                 .filter(|(_, n)| n.unreferenced.is_some())
-                .map(|(id, _)| format!("C{}", id.as_u32()))
+                .map(|(id, _)| format!("C{}", id.token()))
                 .collect();
             for chunk in marked.chunks(32) {
                 writeln!(out, "  class {} unreferenced;", chunk.join(","))?;
@@ -128,20 +128,19 @@ impl GraphFormatter for MermaidFormatter {
         // Collapse identical (src, dst, via-kind) triples. Distinct via
         // kinds between the same pair stay separate, labeled rows so a
         // direct call and a dynamic-dispatch fan-out don't merge.
-        let mut order: Vec<(u32, u32, &str)> = Vec::new();
-        let mut counts: std::collections::HashMap<(u32, u32, &str), u32> =
+        let mut order: Vec<(String, String, &str)> = Vec::new();
+        let mut counts: std::collections::HashMap<(String, String, &str), u32> =
             std::collections::HashMap::new();
         for edge in &graph.edges {
-            let key = (edge.src.as_u32(), edge.dst.as_u32(), via_tag(&edge.via));
-            if counts
-                .insert(key, counts.get(&key).copied().unwrap_or(0) + 1)
-                .is_none()
-            {
+            let key = (edge.src.token(), edge.dst.token(), via_tag(&edge.via));
+            let entry = counts.entry(key.clone()).or_insert(0);
+            *entry += 1;
+            if *entry == 1 {
                 order.push(key);
             }
         }
         for (src, dst, tag) in order {
-            let n = counts[&(src, dst, tag)];
+            let n = counts[&(src.clone(), dst.clone(), tag)];
             let label = match (tag.is_empty(), n > 1) {
                 (true, false) => String::new(),
                 (true, true) => format!("|{n}x|"),

--- a/crates/cgg-format/src/mermaid.rs
+++ b/crates/cgg-format/src/mermaid.rs
@@ -9,6 +9,7 @@ use std::io;
 
 use cgg_core::Graph;
 use cgg_core::graph::Via;
+use cgg_core::ids::CallableId;
 
 use crate::{GraphFormatter, OutputFormat};
 
@@ -128,25 +129,30 @@ impl GraphFormatter for MermaidFormatter {
         // Collapse identical (src, dst, via-kind) triples. Distinct via
         // kinds between the same pair stay separate, labeled rows so a
         // direct call and a dynamic-dispatch fan-out don't merge.
-        let mut order: Vec<(String, String, &str)> = Vec::new();
-        let mut counts: std::collections::HashMap<(String, String, &str), u32> =
+        // Keys stay `Copy` (`CallableId` is a newtype over `u64`) and the
+        // base36 token is rendered only at write time. Keying on the
+        // rendered `String` instead costs two allocations per edge plus
+        // two more per lookup, on graphs that reach millions of edges.
+        let mut order: Vec<(CallableId, CallableId, &str)> = Vec::new();
+        let mut counts: std::collections::HashMap<(CallableId, CallableId, &str), u32> =
             std::collections::HashMap::new();
         for edge in &graph.edges {
-            let key = (edge.src.token(), edge.dst.token(), via_tag(&edge.via));
-            let entry = counts.entry(key.clone()).or_insert(0);
+            let key = (edge.src, edge.dst, via_tag(&edge.via));
+            let entry = counts.entry(key).or_insert(0);
             *entry += 1;
             if *entry == 1 {
                 order.push(key);
             }
         }
         for (src, dst, tag) in order {
-            let n = counts[&(src.clone(), dst.clone(), tag)];
+            let n = counts[&(src, dst, tag)];
             let label = match (tag.is_empty(), n > 1) {
                 (true, false) => String::new(),
                 (true, true) => format!("|{n}x|"),
                 (false, false) => format!("|{tag}|"),
                 (false, true) => format!("|{tag} {n}x|"),
             };
+            let (src, dst) = (src.token(), dst.token());
             if label.is_empty() {
                 writeln!(out, "  C{src} --> C{dst}")?;
             } else {

--- a/crates/cgg-node/README.md
+++ b/crates/cgg-node/README.md
@@ -57,7 +57,7 @@ g.toGraphml();
 g.callableCount;         // without materializing anything
 g.callables;             // [{ id, qualifiedName, kind, language, file, startLine, … }]
 g.edges;                 // [{ src, dst, siteLine, siteByte, confidence, via }]
-g.files;                 // paths, indexed by `callable.file`
+g.files;                 // [{ id, path }] — match `callable.file` by id, not array offset
 g.metrics;               // whole-run counters
 g.notices;               // what the CLI would print to stderr
 g.jobs;                  // worker threads actually used

--- a/crates/cgg-node/index.d.ts
+++ b/crates/cgg-node/index.d.ts
@@ -14,7 +14,7 @@ export declare class Graph {
   /** Resolved call edges. */
   get edges(): Array<Edge>
   /** Analyzed file paths, indexed by `Callable.file`. */
-  get files(): Array<string>
+  get files(): Array<File>
   /** Whole-run counters. */
   get metrics(): Metrics
   /** The diagnostics the CLI would print to stderr, in order. */
@@ -104,13 +104,14 @@ export declare function analyzeSync(paths: string | Array<string>, options?: Ana
 
 /** One callable in the graph. */
 export interface Callable {
-  id: number
+  /** Content-derived id — stable across runs, not a positional index. */
+  id: bigint
   qualifiedName: string
   simpleName: string
   kind: string
   language: string
-  /** Index into [`Graph::files`], not a path. */
-  file: number
+  /** The owning file's id, not a path. Look it up in `Graph::files`. */
+  file: bigint
   startLine: number
   endLine: number
   signatureHint: string
@@ -123,6 +124,16 @@ export interface Callable {
   unreferenced?: string
 }
 
+/** One analyzed source file. */
+export interface File {
+  /**
+   * Content-derived id — matches `Callable.file`, not a positional
+   * index (ids are content hashes now, not array offsets).
+   */
+  id: bigint
+  path: string
+}
+
 /**
  * One resolved call edge.
  *
@@ -131,8 +142,8 @@ export interface Callable {
  * different words.
  */
 export interface Edge {
-  src: number
-  dst: number
+  src: bigint
+  dst: bigint
   siteLine: number
   siteByte: number
   /** `"high"`, `"medium"` or `"low"`. */

--- a/crates/cgg-node/index.d.ts
+++ b/crates/cgg-node/index.d.ts
@@ -13,7 +13,11 @@ export declare class Graph {
   get callables(): Array<Callable>
   /** Resolved call edges. */
   get edges(): Array<Edge>
-  /** Analyzed file paths, indexed by `Callable.file`. */
+  /**
+   * Analyzed files. Match a callable to its file via `Callable.file ==
+   * File.id` — ids are content hashes, not positional indices, so
+   * this is a lookup by id rather than an array offset.
+   */
   get files(): Array<File>
   /** Whole-run counters. */
   get metrics(): Metrics
@@ -105,13 +109,13 @@ export declare function analyzeSync(paths: string | Array<string>, options?: Ana
 /** One callable in the graph. */
 export interface Callable {
   /** Content-derived id — stable across runs, not a positional index. */
-  id: bigint
+  id: number
   qualifiedName: string
   simpleName: string
   kind: string
   language: string
   /** The owning file's id, not a path. Look it up in `Graph::files`. */
-  file: bigint
+  file: number
   startLine: number
   endLine: number
   signatureHint: string
@@ -124,16 +128,6 @@ export interface Callable {
   unreferenced?: string
 }
 
-/** One analyzed source file. */
-export interface File {
-  /**
-   * Content-derived id — matches `Callable.file`, not a positional
-   * index (ids are content hashes now, not array offsets).
-   */
-  id: bigint
-  path: string
-}
-
 /**
  * One resolved call edge.
  *
@@ -142,8 +136,8 @@ export interface File {
  * different words.
  */
 export interface Edge {
-  src: bigint
-  dst: bigint
+  src: number
+  dst: number
   siteLine: number
   siteByte: number
   /** `"high"`, `"medium"` or `"low"`. */
@@ -154,6 +148,16 @@ export interface Edge {
    * or `"framework_entry"`. Filter on this to keep only edges you trust.
    */
   via: string
+}
+
+/** One analyzed source file. */
+export interface File {
+  /**
+   * Content-derived id — matches `Callable.file`, not a positional
+   * index (ids are content hashes now, not array offsets).
+   */
+  id: number
+  path: string
 }
 
 /** Every language id cgg can analyze, in registry order. */

--- a/crates/cgg-node/src/lib.rs
+++ b/crates/cgg-node/src/lib.rs
@@ -65,13 +65,14 @@ pub struct AnalyzeOptions {
 /// One callable in the graph.
 #[napi(object)]
 pub struct Callable {
-    pub id: u32,
+    /// Content-derived id — stable across runs, not a positional index.
+    pub id: i64,
     pub qualified_name: String,
     pub simple_name: String,
     pub kind: String,
     pub language: String,
-    /// Index into [`Graph::files`], not a path.
-    pub file: u32,
+    /// The owning file's id, not a path. Look it up in `Graph::files`.
+    pub file: i64,
     pub start_line: u32,
     pub end_line: u32,
     pub signature_hint: String,
@@ -82,6 +83,15 @@ pub struct Callable {
     pub unreferenced: Option<String>,
 }
 
+/// One analyzed source file.
+#[napi(object)]
+pub struct File {
+    /// Content-derived id — matches `Callable.file`, not a positional
+    /// index (ids are content hashes now, not array offsets).
+    pub id: i64,
+    pub path: String,
+}
+
 /// One resolved call edge.
 ///
 /// Field-for-field the same as the Python module's `Edge`, deliberately:
@@ -89,8 +99,8 @@ pub struct Callable {
 /// different words.
 #[napi(object)]
 pub struct Edge {
-    pub src: u32,
-    pub dst: u32,
+    pub src: i64,
+    pub dst: i64,
     pub site_line: u32,
     pub site_byte: u32,
     /// `"high"`, `"medium"` or `"low"`.
@@ -220,12 +230,12 @@ impl Graph {
             .callables
             .values()
             .map(|c| Callable {
-                id: c.id.as_u32(),
+                id: c.id.as_u64() as i64,
                 qualified_name: c.qualified_name.clone(),
                 simple_name: c.simple_name.clone(),
                 kind: kind_str(c.kind).to_string(),
                 language: c.language.clone(),
-                file: c.file.as_u32(),
+                file: c.file.as_u64() as i64,
                 start_line: c.start_line,
                 end_line: c.end_line,
                 signature_hint: c.signature_hint.clone(),
@@ -245,8 +255,8 @@ impl Graph {
             .edges
             .iter()
             .map(|e| Edge {
-                src: e.src.as_u32(),
-                dst: e.dst.as_u32(),
+                src: e.src.as_u64() as i64,
+                dst: e.dst.as_u64() as i64,
                 site_line: e.site_line,
                 site_byte: e.site_byte,
                 confidence: confidence_str(e.confidence).to_string(),
@@ -255,14 +265,19 @@ impl Graph {
             .collect()
     }
 
-    /// Analyzed file paths, indexed by `Callable.file`.
+    /// Analyzed files. Match a callable to its file via `Callable.file ==
+    /// File.id` — ids are content hashes, not positional indices, so
+    /// this is a lookup by id rather than an array offset.
     #[napi(getter)]
-    pub fn files(&self) -> Vec<String> {
+    pub fn files(&self) -> Vec<File> {
         self.outcome
             .graph
             .files
             .values()
-            .map(|f| f.path.display().to_string())
+            .map(|f| File {
+                id: f.id.as_u64() as i64,
+                path: f.path.display().to_string(),
+            })
             .collect()
     }
 

--- a/crates/cgg-node/tests/analyze.test.js
+++ b/crates/cgg-node/tests/analyze.test.js
@@ -73,7 +73,12 @@ test("callables and edges carry the documented shape", async () => {
     assert.ok(k in e, `edge missing ${k}`);
   }
   assert.ok(["high", "medium", "low"].includes(e.confidence));
-  assert.ok(c.file >= 0 && c.file < g.files.length, "file index out of range");
+  // Ids are content-derived hashes now, not positional indices, so
+  // membership in the file list is what's checkable — not a range.
+  assert.ok(
+    g.files.some((f) => f.id === c.file),
+    "callable's file id does not match any analyzed file",
+  );
   // Not a debug-formatted string: 0.6.2 briefly shipped `"\"pub\""`.
   assert.ok(!c.visibility.includes('"'), `visibility is quoted: ${c.visibility}`);
 });

--- a/crates/cgg-py/python/cgg/_cgg.pyi
+++ b/crates/cgg-py/python/cgg/_cgg.pyi
@@ -39,7 +39,8 @@ class Callable:
     def language(self) -> str: ...
     @property
     def file(self) -> int:
-        """Index into `Graph.files`, not a path."""
+        """The owning file's id (match against `File.id`), not a path
+        and not a positional index — ids are content hashes."""
 
     @property
     def start_line(self) -> int: ...

--- a/crates/cgg-py/src/lib.rs
+++ b/crates/cgg-py/src/lib.rs
@@ -50,7 +50,7 @@ fn to_py_err(e: anyhow::Error) -> PyErr {
 #[derive(Clone)]
 pub struct Callable {
     #[pyo3(get)]
-    id: u32,
+    id: u64,
     #[pyo3(get)]
     qualified_name: String,
     #[pyo3(get)]
@@ -60,7 +60,7 @@ pub struct Callable {
     #[pyo3(get)]
     language: String,
     #[pyo3(get)]
-    file: u32,
+    file: u64,
     #[pyo3(get)]
     start_line: u32,
     #[pyo3(get)]
@@ -111,12 +111,12 @@ impl Callable {
             framework_entry: _,
         } = n;
         Self {
-            id: id.as_u32(),
+            id: id.as_u64(),
             qualified_name: qualified_name.clone(),
             simple_name: simple_name.clone(),
             kind: kind_str(*kind),
             language: language.clone(),
-            file: file.as_u32(),
+            file: file.as_u64(),
             start_line: *start_line,
             end_line: *end_line,
             signature_hint: signature_hint.clone(),
@@ -168,9 +168,9 @@ impl Callable {
 #[derive(Clone)]
 pub struct Edge {
     #[pyo3(get)]
-    src: u32,
+    src: u64,
     #[pyo3(get)]
-    dst: u32,
+    dst: u64,
     #[pyo3(get)]
     site_line: u32,
     #[pyo3(get)]
@@ -200,8 +200,8 @@ impl Edge {
             resolver: _,
         } = e;
         Self {
-            src: src.as_u32(),
-            dst: dst.as_u32(),
+            src: src.as_u64(),
+            dst: dst.as_u64(),
             site_line: *site_line,
             site_byte: *site_byte,
             confidence: confidence_str(*confidence),
@@ -244,7 +244,7 @@ impl Edge {
 #[derive(Clone)]
 pub struct File {
     #[pyo3(get)]
-    id: u32,
+    id: u64,
     #[pyo3(get)]
     path: PathBuf,
     #[pyo3(get)]
@@ -281,7 +281,7 @@ impl File {
             test_role: _,
         } = f;
         Self {
-            id: id.as_u32(),
+            id: id.as_u64(),
             path: path.clone(),
             language: language.clone(),
             detected_via: detected_via.clone(),
@@ -370,15 +370,15 @@ pub struct Graph {
     /// Without them `callers_of`/`callees_of` are O(E) and `callable()` is
     /// O(N), so the obvious `for c in g.callables: g.callers_of(c)` is
     /// O(N*E): 8.6M edge visits on cgg's own graph, ~10^10 on a large one.
-    by_name: OnceLock<HashMap<String, u32>>,
+    by_name: OnceLock<HashMap<String, u64>>,
     adjacency: OnceLock<Adjacency>,
 }
 
 /// Inbound and outbound neighbours per callable id.
 #[derive(Default)]
 struct Adjacency {
-    callers: HashMap<u32, Vec<u32>>,
-    callees: HashMap<u32, Vec<u32>>,
+    callers: HashMap<u64, Vec<u64>>,
+    callees: HashMap<u64, Vec<u64>>,
 }
 
 impl Graph {
@@ -414,12 +414,12 @@ impl Graph {
         }
     }
 
-    fn by_name(&self) -> &HashMap<String, u32> {
+    fn by_name(&self) -> &HashMap<String, u64> {
         self.by_name.get_or_init(|| {
             self.inner
                 .callables
                 .values()
-                .map(|c| (c.qualified_name.clone(), c.id.as_u32()))
+                .map(|c| (c.qualified_name.clone(), c.id.as_u64()))
                 .collect()
         })
     }
@@ -429,13 +429,13 @@ impl Graph {
             let mut a = Adjacency::default();
             for e in &self.inner.edges {
                 a.callees
-                    .entry(e.src.as_u32())
+                    .entry(e.src.as_u64())
                     .or_default()
-                    .push(e.dst.as_u32());
+                    .push(e.dst.as_u64());
                 a.callers
-                    .entry(e.dst.as_u32())
+                    .entry(e.dst.as_u64())
                     .or_default()
-                    .push(e.src.as_u32());
+                    .push(e.src.as_u64());
             }
             a
         })
@@ -443,19 +443,29 @@ impl Graph {
 
     /// Callables for a list of ids.
     ///
-    /// Sorted and deduplicated: ids are assigned in graph order, so sorting
-    /// restores graph order without scanning the graph, and dedup means two
-    /// call sites from one caller yield one entry rather than two.
-    fn nodes_for(&self, ids: Option<&Vec<u32>>) -> Vec<Callable> {
+    /// Sorted by position in the graph and deduplicated. Ids are
+    /// content-derived hashes now, not sequential indices, so sorting by
+    /// *value* would no longer restore graph order — instead we sort by
+    /// each id's position in `self.inner.callables` (an `IndexMap`, so
+    /// that lookup is O(1) and the order it reports is insertion/analysis
+    /// order). Dedup means two call sites from one caller yield one entry
+    /// rather than two.
+    fn nodes_for(&self, ids: Option<&Vec<u64>>) -> Vec<Callable> {
         let Some(ids) = ids else { return Vec::new() };
         let mut ids = ids.clone();
         ids.sort_unstable();
         ids.dedup();
+        ids.sort_unstable_by_key(|id| {
+            self.inner
+                .callables
+                .get_index_of(&cgg_core::ids::CallableId::new_u64(*id))
+                .unwrap_or(usize::MAX)
+        });
         ids.iter()
             .filter_map(|id| {
                 self.inner
                     .callables
-                    .get(&cgg_core::ids::CallableId::new(*id))
+                    .get(&cgg_core::ids::CallableId::new_u64(*id))
             })
             .map(Callable::from_node)
             .collect()
@@ -580,7 +590,7 @@ impl Graph {
         let id = *self.by_name().get(qualified_name)?;
         self.inner
             .callables
-            .get(&cgg_core::ids::CallableId::new(id))
+            .get(&cgg_core::ids::CallableId::new_u64(id))
             .map(Callable::from_node)
     }
 
@@ -602,7 +612,7 @@ impl Graph {
 
 impl Graph {
     /// Accept a `Callable` or a qualified name.
-    fn resolve_id(&self, target: &Bound<'_, PyAny>) -> PyResult<u32> {
+    fn resolve_id(&self, target: &Bound<'_, PyAny>) -> PyResult<u64> {
         // `cast` + `get`, not `extract`: the class is `frozen`, so this
         // reads the id straight out of the cell instead of cloning five
         // `String`s and a `Vec` to throw them away.
@@ -611,9 +621,11 @@ impl Graph {
         }
         if let Ok(name) = target.extract::<String>() {
             // An unmatched name yields an unmatched id, so the caller gets
-            // `[]` rather than an exception. Ids start at 0, so u32::MAX is
-            // never minted.
-            return Ok(self.by_name().get(&name).copied().unwrap_or(u32::MAX));
+            // `[]` rather than an exception. Ids are content hashes now
+            // rather than a sequential counter starting at 0, but they
+            // are drawn from at most 64 bits, so u64::MAX is
+            // vanishingly unlikely ever to be minted for a real node.
+            return Ok(self.by_name().get(&name).copied().unwrap_or(u64::MAX));
         }
         Err(PyValueError::new_err(
             "expected a Callable or a qualified name",

--- a/crates/cgg-resolve/src/cross_file.rs
+++ b/crates/cgg-resolve/src/cross_file.rs
@@ -427,9 +427,18 @@ pub fn resolve(graph: &Graph, facts: &[FileFacts], fanout_cap: usize) -> CrossFi
             include_by_last.entry(name).or_default().push(f);
         }
     }
-    for v in include_by_last.values_mut() {
-        v.sort_by_key(|f| f.file);
-    }
+    // No sort here on purpose. The comment above promises "lowest FileId
+    // among the matches"; `facts` arrives in walk order and the loop
+    // above pushes in that order, so each bucket already holds it — the
+    // old `sort_by_key(|f| f.file.as_u32())` was a no-op that only
+    // looked load-bearing. It stops being a no-op the moment ids become
+    // content hashes, at which point it actively scrambles the buckets,
+    // and this walk is order-sensitive: it memoizes by remaining depth
+    // and caps candidates per name, so which header expands first
+    // decides what resolves and at what confidence. Re-sorting by path
+    // would restore the order but pay a `PathBuf` comparison per probe
+    // — measured at +30% on erlang-otp. Keeping insertion order is both
+    // correct and free.
 
     // Per-file and independent: the body reads the shared indexes
     // (`by_qn`, `by_simple`, `by_owner_method`, `reexports`) and writes

--- a/crates/cgg-resolve/src/cross_file.rs
+++ b/crates/cgg-resolve/src/cross_file.rs
@@ -221,10 +221,11 @@ pub fn resolve(graph: &Graph, facts: &[FileFacts], fanout_cap: usize) -> CrossFi
     // per resolved reference. That is O(references x edges), which stayed
     // invisible while PHP resolved almost nothing and became ~4s of a
     // Laravel run the moment it started resolving properly.
-    let existing_edges: std::collections::HashSet<(u32, u32, u32)> = graph
+    // Keyed by (src, dst, call-site byte offset).
+    let existing_edges: std::collections::HashSet<(CallableId, CallableId, u32)> = graph
         .edges
         .iter()
-        .map(|e| (e.src.as_u32(), e.dst.as_u32(), e.site_byte))
+        .map(|e| (e.src, e.dst, e.site_byte))
         .collect();
     let mut out = CrossFileOutput::default();
     let _sp_idx = cgg_core::profile::span("xfile::index-build");
@@ -427,7 +428,7 @@ pub fn resolve(graph: &Graph, facts: &[FileFacts], fanout_cap: usize) -> CrossFi
         }
     }
     for v in include_by_last.values_mut() {
-        v.sort_by_key(|f| f.file.as_u32());
+        v.sort_by_key(|f| f.file);
     }
 
     // Per-file and independent: the body reads the shared indexes
@@ -1075,11 +1076,7 @@ pub fn resolve(graph: &Graph, facts: &[FileFacts], fanout_cap: usize) -> CrossFi
                     if *cid == src {
                         continue;
                     }
-                    let dup = existing_edges.contains(&(
-                        src.as_u32(),
-                        cid.as_u32(),
-                        r.site_byte,
-                    ));
+                    let dup = existing_edges.contains(&(src, *cid, r.site_byte));
                     if !dup {
                         out.edges.push(CallEdge {
                             src,
@@ -1165,11 +1162,7 @@ pub fn resolve(graph: &Graph, facts: &[FileFacts], fanout_cap: usize) -> CrossFi
                                 continue;
                             }
                             // Avoid duplicating intra-file-emitted edges.
-                            if existing_edges.contains(&(
-                                src.as_u32(),
-                                cid.as_u32(),
-                                r.site_byte,
-                            )) {
+                            if existing_edges.contains(&(src, cid, r.site_byte)) {
                                 continue;
                             }
                             out.edges.push(CallEdge {

--- a/crates/cgg-resolve/src/deadcode/mod.rs
+++ b/crates/cgg-resolve/src/deadcode/mod.rs
@@ -480,7 +480,7 @@ pub fn analyze(
                 .iter()
                 .filter_map(|&i| node_at(i).map(|x| x.file))
                 .collect();
-            files.sort_unstable_by_key(|f| f.as_u32());
+            files.sort_unstable();
             files.dedup();
             let mut languages: Vec<String> =
                 members.iter().map(|&i| lang_at(i)).collect();

--- a/crates/cgg-resolve/src/deadcode/mod.rs
+++ b/crates/cgg-resolve/src/deadcode/mod.rs
@@ -480,7 +480,8 @@ pub fn analyze(
                 .iter()
                 .filter_map(|&i| node_at(i).map(|x| x.file))
                 .collect();
-            files.sort_unstable();
+            // Discovery order (IndexMap position), not hash order.
+            files.sort_by_cached_key(|f| graph.files.get_index_of(f));
             files.dedup();
             let mut languages: Vec<String> =
                 members.iter().map(|&i| lang_at(i)).collect();

--- a/crates/cgg-resolve/src/deadcode/roots.rs
+++ b/crates/cgg-resolve/src/deadcode/roots.rs
@@ -648,7 +648,10 @@ pub(crate) fn discover(
         );
     }
 
-    set.records.sort_by_key(|a| a.id);
+    // Discovery order (IndexMap position), not hash order — this is a
+    // user-facing report and graph order is the readable one.
+    set.records
+        .sort_by_cached_key(|a| graph.callables.get_index_of(&a.id));
     set.production.sort_unstable();
     set.test.sort_unstable();
     for v in set.rules_by_language.values_mut() {

--- a/crates/cgg-resolve/src/deadcode/roots.rs
+++ b/crates/cgg-resolve/src/deadcode/roots.rs
@@ -648,8 +648,7 @@ pub(crate) fn discover(
         );
     }
 
-    set.records
-        .sort_by(|a, b| a.id.as_u32().cmp(&b.id.as_u32()));
+    set.records.sort_by_key(|a| a.id);
     set.production.sort_unstable();
     set.test.sort_unstable();
     for v in set.rules_by_language.values_mut() {

--- a/crates/cgg-resolve/src/descriptor.rs
+++ b/crates/cgg-resolve/src/descriptor.rs
@@ -139,7 +139,13 @@ pub fn link_descriptors(graph: &Graph) -> Vec<CallEdge> {
         }
     }
 
-    out.sort_by_key(|e| (e.src, e.dst));
+    // Discovery order, not hash order.
+    out.sort_by_cached_key(|e| {
+        (
+            graph.callables.get_index_of(&e.src),
+            graph.callables.get_index_of(&e.dst),
+        )
+    });
     out
 }
 

--- a/crates/cgg-resolve/src/descriptor.rs
+++ b/crates/cgg-resolve/src/descriptor.rs
@@ -139,7 +139,7 @@ pub fn link_descriptors(graph: &Graph) -> Vec<CallEdge> {
         }
     }
 
-    out.sort_by_key(|e| (e.src.as_u32(), e.dst.as_u32()));
+    out.sort_by_key(|e| (e.src, e.dst));
     out
 }
 
@@ -177,8 +177,8 @@ mod tests {
         ]);
         let e = link_descriptors(&g);
         assert_eq!(e.len(), 1, "{e:?}");
-        assert_eq!(e[0].src.as_u32(), 0);
-        assert_eq!(e[0].dst.as_u32(), 1);
+        assert_eq!(e[0].src.as_u64(), 0);
+        assert_eq!(e[0].dst.as_u64(), 1);
     }
 
     #[test]

--- a/crates/cgg-resolve/src/dispatch.rs
+++ b/crates/cgg-resolve/src/dispatch.rs
@@ -138,7 +138,7 @@ mod tests {
         assert_eq!(edges.len(), 2);
         assert!(edges.iter().all(|e| e.src == CallableId::new(0)));
         assert!(edges.iter().all(|e| matches!(e.via, Via::Dynamic)));
-        let dsts: Vec<u32> = edges.iter().map(|e| e.dst.as_u32()).collect();
+        let dsts: Vec<u64> = edges.iter().map(|e| e.dst.as_u64()).collect();
         assert!(dsts.contains(&1) && dsts.contains(&2));
     }
 

--- a/crates/cgg-resolve/src/frameworks/mod.rs
+++ b/crates/cgg-resolve/src/frameworks/mod.rs
@@ -1435,10 +1435,10 @@ fn dedup(entries: &mut Vec<FrameworkEntry>) {
     // (target, framework, route) slot and evict the precise one — a
     // Rails `root to: 'photos#index'` losing to "declares
     // ApplicationController", which is the same entry described worse.
-    let mut best: HashMap<u32, EntryShape> = HashMap::new();
+    let mut best: HashMap<CallableId, EntryShape> = HashMap::new();
     for e in entries.iter() {
         let rank = shape_rank(e.shape);
-        best.entry(e.target.as_u32())
+        best.entry(e.target)
             .and_modify(|s| {
                 if rank < shape_rank(*s) {
                     *s = e.shape;
@@ -1446,20 +1446,17 @@ fn dedup(entries: &mut Vec<FrameworkEntry>) {
             })
             .or_insert(e.shape);
     }
-    entries.retain(|e| best.get(&e.target.as_u32()) == Some(&e.shape));
+    entries.retain(|e| best.get(&e.target) == Some(&e.shape));
 
     // Then one entry per (target, framework, route). Two rules can
     // legitimately match the same handler — a project using both FastAPI
     // and Flask sees `@app.get` under both vocabularies — and two nodes
     // for one handler would double-count the attack surface.
-    let mut seen: BTreeSet<(u32, String, String)> = BTreeSet::new();
-    entries.retain(|e| {
-        seen.insert((e.target.as_u32(), e.framework.clone(), e.route.clone()))
-    });
+    let mut seen: BTreeSet<(CallableId, String, String)> = BTreeSet::new();
+    entries.retain(|e| seen.insert((e.target, e.framework.clone(), e.route.clone())));
     entries.sort_by(|a, b| {
         a.target
-            .as_u32()
-            .cmp(&b.target.as_u32())
+            .cmp(&b.target)
             .then_with(|| a.framework.cmp(&b.framework))
             .then_with(|| a.route.cmp(&b.route))
     });

--- a/crates/cgg-resolve/src/frameworks/mod.rs
+++ b/crates/cgg-resolve/src/frameworks/mod.rs
@@ -147,7 +147,7 @@ pub fn detect(
         })
         .collect();
 
-    dedup(&mut entries);
+    dedup(&mut entries, graph);
     let coverage = evidence.into_coverage(&all, &entries, graph);
     FrameworkOutcome { entries, coverage }
 }
@@ -1429,7 +1429,7 @@ fn owner_is_close(declared: &str, wanted: &str) -> bool {
 }
 
 /// Collapse the matches on one handler to the best description of it.
-fn dedup(entries: &mut Vec<FrameworkEntry>) {
+fn dedup(entries: &mut Vec<FrameworkEntry>, graph: &Graph) {
     // Strongest shape per target FIRST. Doing it the other way round
     // lets a weaker match that merely ran earlier claim the
     // (target, framework, route) slot and evict the precise one — a
@@ -1454,11 +1454,17 @@ fn dedup(entries: &mut Vec<FrameworkEntry>) {
     // for one handler would double-count the attack surface.
     let mut seen: BTreeSet<(CallableId, String, String)> = BTreeSet::new();
     entries.retain(|e| seen.insert((e.target, e.framework.clone(), e.route.clone())));
-    entries.sort_by(|a, b| {
-        a.target
-            .cmp(&b.target)
-            .then_with(|| a.framework.cmp(&b.framework))
-            .then_with(|| a.route.cmp(&b.route))
+    // Order by the target's position in the graph (discovery order),
+    // not by id value: ids are content hashes now, so ordering by value
+    // is arbitrary — and this order decides which entry wins when two
+    // share a synthesized node name in `synthesize_entry_nodes`, which
+    // is where the entry node's `language` comes from.
+    entries.sort_by_cached_key(|e| {
+        (
+            graph.callables.get_index_of(&e.target),
+            e.framework.clone(),
+            e.route.clone(),
+        )
     });
 }
 
@@ -1897,13 +1903,13 @@ mod tests {
         b.route = "get(\"/x\")".into();
         b.evidence = "precise".into();
         let mut v = vec![a.clone(), b];
-        dedup(&mut v);
+        dedup(&mut v, &Graph::new());
         assert_eq!(v.len(), 1);
         assert_eq!(v[0].shape, EntryShape::Attribute);
         // And an unrelated target survives alongside it.
         a.target = CallableId::new(8);
         let mut v2 = vec![v[0].clone(), a];
-        dedup(&mut v2);
+        dedup(&mut v2, &Graph::new());
         assert_eq!(v2.len(), 2);
     }
 

--- a/crates/cgg/src/lib.rs
+++ b/crates/cgg/src/lib.rs
@@ -31,6 +31,9 @@ mod options;
 mod outcome;
 mod query;
 mod since;
+mod stable_ids;
+
+use stable_ids::StableIds;
 
 pub use options::RunOptions;
 pub use outcome::{Emission, RunOutcome};
@@ -257,8 +260,7 @@ fn analyze_in_pool(opts: &RunOptions) -> Result<RunOutcome> {
         |lang: &str| -> bool { lang_filter.is_empty() || lang_filter.contains(&lang) };
 
     let parse_started = Instant::now();
-    let mut next_file_id: u32 = 0;
-    let mut next_callable_id: u32 = 0;
+    let mut stable_ids = StableIds::new();
 
     // Collected facts per file, used by the intra-file linker below.
     let mut all_facts: Vec<FileFacts> = Vec::new();
@@ -419,8 +421,8 @@ fn analyze_in_pool(opts: &RunOptions) -> Result<RunOutcome> {
                 });
                 metrics.bytes_processed += fr.size_bytes;
 
-                let file_id = FileId::new(next_file_id);
-                next_file_id += 1;
+                let relative_path = fr.path.to_string_lossy().into_owned();
+                let file_id = stable_ids.file(&relative_path);
 
                 // Classify test code once, from (path, language), and
                 // record it on both the graph and the audit so the
@@ -464,8 +466,13 @@ fn analyze_in_pool(opts: &RunOptions) -> Result<RunOutcome> {
                     // Fix the file ID (was placeholder 0 during parallel phase).
                     facts.file = file_id;
                     for (idx, d) in facts.definitions.iter().enumerate() {
-                        let cid = CallableId::new(next_callable_id);
-                        next_callable_id += 1;
+                        let owner = cgg_resolve::names::owner_from_qn(&d.qualified_name);
+                        let cid = stable_ids.callable(
+                            &fr.lang,
+                            &relative_path,
+                            owner,
+                            &d.qualified_name,
+                        );
                         def_ids.insert((file_id, idx as u32), cid);
 
                         graph.add_callable(CallableNode {
@@ -857,8 +864,7 @@ fn analyze_in_pool(opts: &RunOptions) -> Result<RunOutcome> {
         synthesize_exit_nodes(
             &mut graph,
             &file_records,
-            &mut next_file_id,
-            &mut next_callable_id,
+            &mut stable_ids,
             opts.include_external,
             opts.include_stdlib,
         );
@@ -896,12 +902,7 @@ fn analyze_in_pool(opts: &RunOptions) -> Result<RunOutcome> {
         .collect();
     if !framework_out.entries.is_empty() {
         let _s = cgg_core::profile::span("post::entry-nodes");
-        synthesize_entry_nodes(
-            &mut graph,
-            &framework_out.entries,
-            &mut next_file_id,
-            &mut next_callable_id,
-        );
+        synthesize_entry_nodes(&mut graph, &framework_out.entries, &mut stable_ids);
     }
     let framework_coverage = framework_out.coverage;
 
@@ -1772,8 +1773,7 @@ fn sentinel_file(id: FileId, path: &str, lang: &str) -> GraphFileRecord {
 fn synthesize_exit_nodes(
     graph: &mut Graph,
     file_records: &[AuditFileRecord],
-    next_file_id: &mut u32,
-    next_callable_id: &mut u32,
+    stable_ids: &mut StableIds,
     include_external: bool,
     include_stdlib: bool,
 ) {
@@ -1820,26 +1820,28 @@ fn synthesize_exit_nodes(
                 let node_id = if let Some(&id) = node_ids.get(&key) {
                     id
                 } else {
+                    let sentinel_path = if is_external {
+                        "<external>"
+                    } else {
+                        "<stdlib>"
+                    };
                     let file_id = if is_external {
                         *external_file.get_or_insert_with(|| {
-                            let fid = FileId::new(*next_file_id);
-                            *next_file_id += 1;
+                            let fid = stable_ids.file(sentinel_path);
                             graph.add_file(sentinel_file(fid, "<external>", "external"))
                         })
                     } else {
                         *stdlib_file.get_or_insert_with(|| {
-                            let fid = FileId::new(*next_file_id);
-                            *next_file_id += 1;
+                            let fid = stable_ids.file(sentinel_path);
                             graph.add_file(sentinel_file(fid, "<stdlib>", "stdlib"))
                         })
                     };
-                    let id = CallableId::new(*next_callable_id);
-                    *next_callable_id += 1;
                     let qn = if call.receiver_hint.is_empty() {
                         format!("<{kind_label}>::{}", call.name)
                     } else {
                         format!("<{kind_label}>::{}::{}", call.receiver_hint, call.name)
                     };
+                    let id = stable_ids.callable(&lang, sentinel_path, None, &qn);
                     graph.add_callable(CallableNode {
                         id,
                         qualified_name: qn,
@@ -1893,8 +1895,7 @@ fn synthesize_exit_nodes(
 fn synthesize_entry_nodes(
     graph: &mut Graph,
     entries: &[cgg_core::frameworks::FrameworkEntry],
-    next_file_id: &mut u32,
-    next_callable_id: &mut u32,
+    stable_ids: &mut StableIds,
 ) {
     use cgg_core::frameworks::FRAMEWORK_ENTRY_SENTINEL;
 
@@ -1912,27 +1913,26 @@ fn synthesize_entry_nodes(
             id
         } else {
             let file_id = *sentinel.get_or_insert_with(|| {
-                let fid = FileId::new(*next_file_id);
-                *next_file_id += 1;
+                let fid = stable_ids.file(FRAMEWORK_ENTRY_SENTINEL);
                 graph.add_file(sentinel_file(
                     fid,
                     FRAMEWORK_ENTRY_SENTINEL,
                     "framework-entry",
                 ))
             });
-            let id = CallableId::new(*next_callable_id);
-            *next_callable_id += 1;
+            let language = graph
+                .callables
+                .get(&entry.target)
+                .map(|c| c.language.clone())
+                .unwrap_or_default();
+            let id = stable_ids.callable(&language, FRAMEWORK_ENTRY_SENTINEL, None, &qn);
             let simple = qn.rsplit("::").next().unwrap_or(&qn).to_string();
             graph.add_callable(CallableNode {
                 id,
                 qualified_name: qn.clone(),
                 simple_name: simple,
                 kind: CallableKind::Function,
-                language: graph
-                    .callables
-                    .get(&entry.target)
-                    .map(|c| c.language.clone())
-                    .unwrap_or_default(),
+                language,
                 file: file_id,
                 start_line: 0,
                 end_line: 0,
@@ -1992,14 +1992,15 @@ fn trait_impl_target_from_qn(qn: &str) -> Option<String> {
 fn dedup_edges(graph: &mut Graph) {
     use cgg_core::graph::Confidence;
     use std::collections::HashMap;
-    let mut best: HashMap<(u32, u32, u32), usize> = HashMap::new();
+    use cgg_core::ids::CallableId;
+    let mut best: HashMap<(CallableId, CallableId, u32), usize> = HashMap::new();
     let conf_rank = |c: Confidence| match c {
         Confidence::High => 2,
         Confidence::Medium => 1,
         Confidence::Low => 0,
     };
     for (i, e) in graph.edges.iter().enumerate() {
-        let key = (e.src.as_u32(), e.dst.as_u32(), e.site_byte);
+        let key = (e.src, e.dst, e.site_byte);
         let entry = best.entry(key).or_insert(i);
         if conf_rank(e.confidence) > conf_rank(graph.edges[*entry].confidence) {
             *entry = i;

--- a/crates/cgg/src/lib.rs
+++ b/crates/cgg/src/lib.rs
@@ -467,11 +467,16 @@ fn analyze_in_pool(opts: &RunOptions) -> Result<RunOutcome> {
                     facts.file = file_id;
                     for (idx, d) in facts.definitions.iter().enumerate() {
                         let owner = cgg_resolve::names::owner_from_qn(&d.qualified_name);
+                        // The signature is part of the key: without it,
+                        // overloads sharing a qualified name hash
+                        // identically — 17.7% of the benchmark corpus —
+                        // and their ids fall to declaration order.
                         let cid = stable_ids.callable(
                             &fr.lang,
                             &relative_path,
                             owner,
                             &d.qualified_name,
+                            &d.signature_hint,
                         );
                         def_ids.insert((file_id, idx as u32), cid);
 
@@ -1841,7 +1846,10 @@ fn synthesize_exit_nodes(
                     } else {
                         format!("<{kind_label}>::{}::{}", call.receiver_hint, call.name)
                     };
-                    let id = stable_ids.callable(&lang, sentinel_path, None, &qn);
+                    // Synthetic: `node_ids` already dedupes these by key, so no
+                    // two reach here with the same qualified name and a
+                    // constant byte offset is unambiguous.
+                    let id = stable_ids.callable(&lang, sentinel_path, None, &qn, "");
                     graph.add_callable(CallableNode {
                         id,
                         qualified_name: qn,
@@ -1925,7 +1933,9 @@ fn synthesize_entry_nodes(
                 .get(&entry.target)
                 .map(|c| c.language.clone())
                 .unwrap_or_default();
-            let id = stable_ids.callable(&language, FRAMEWORK_ENTRY_SENTINEL, None, &qn);
+            // Synthetic and deduped by qualified name just above.
+            let id =
+                stable_ids.callable(&language, FRAMEWORK_ENTRY_SENTINEL, None, &qn, "");
             let simple = qn.rsplit("::").next().unwrap_or(&qn).to_string();
             graph.add_callable(CallableNode {
                 id,
@@ -1991,8 +2001,8 @@ fn trait_impl_target_from_qn(qn: &str) -> Option<String> {
 /// triple, preferring the highest confidence.
 fn dedup_edges(graph: &mut Graph) {
     use cgg_core::graph::Confidence;
-    use std::collections::HashMap;
     use cgg_core::ids::CallableId;
+    use std::collections::HashMap;
     let mut best: HashMap<(CallableId, CallableId, u32), usize> = HashMap::new();
     let conf_rank = |c: Confidence| match c {
         Confidence::High => 2,

--- a/crates/cgg/src/query.rs
+++ b/crates/cgg/src/query.rs
@@ -218,7 +218,11 @@ fn paths_through(
     // run. Without the cap the result was the same set either way, which
     // is why this stayed invisible: the defect only appears once
     // truncation actually turns work away.
-    entries.sort_unstable();
+    // Sorted by graph position, not by id value: ids are content
+    // hashes, so sorting by value is an arbitrary order, and this
+    // order decides WHICH entries get walked before `--max-paths`
+    // stops the walk.
+    entries.sort_by_cached_key(|id| graph.callables.get_index_of(id));
 
     // DFS from each entry, collecting nodes on paths that hit a seed.
     let mut on_path: HashSet<CallableId> = HashSet::new();

--- a/crates/cgg/src/query.rs
+++ b/crates/cgg/src/query.rs
@@ -218,7 +218,7 @@ fn paths_through(
     // run. Without the cap the result was the same set either way, which
     // is why this stayed invisible: the defect only appears once
     // truncation actually turns work away.
-    entries.sort_unstable_by_key(|id| id.as_u32());
+    entries.sort_unstable();
 
     // DFS from each entry, collecting nodes on paths that hit a seed.
     let mut on_path: HashSet<CallableId> = HashSet::new();

--- a/crates/cgg/src/stable_ids.rs
+++ b/crates/cgg/src/stable_ids.rs
@@ -1,0 +1,258 @@
+//! Content-derived, stable id allocation.
+//!
+//! Replaces the old per-run sequential `u32` counters. An id here is a
+//! blake3 hash of a node's *identity* — a file's relative path, or a
+//! callable's `(language, file, owner, qualified_name)` tuple — so the
+//! same node gets the same id on every run, and adding or removing an
+//! unrelated node elsewhere in the tree never perturbs it.
+//!
+//! # Collision handling
+//!
+//! The default candidate id is the first 52 bits of the identity's blake3
+//! hash. On the rare collision (another node already claimed that exact
+//! 52-bit value), we escalate by pulling *more bits from the same
+//! blake3 output* via `finalize_xof()` — first 64 bits, then 96, doubling
+//! until a free slot is found.
+//!
+//! This escalation is a pure function of the colliding item's own hash
+//! stream. It never compares to, or depends on the identity of, whichever
+//! other node it collided with — no lexicographic tie-break, no
+//! "insertion order decides who keeps the short form". That property is
+//! what makes ids stable under unrelated edits: if node A collided with
+//! node B in one run, and a later run adds/removes some unrelated node C
+//! before A or B is ever hashed, A and B still escalate exactly as they
+//! did before, because nothing about their own escalation reads the
+//! *other* colliding party, only their own extended hash stream and the
+//! current `seen` set. Compare that to a scheme that says "whichever
+//! sorts first keeps the short id" — that tie-break's outcome depends on
+//! which nodes exist at all, so an unrelated addition could flip who
+//! gets escalated.
+use std::collections::HashSet;
+
+/// How many bits of the blake3 hash are used for the initial candidate
+/// id. 52 bits leaves headroom under `u64` for the escalation doubling
+/// (52 -> 64 is still one u64) while giving a huge birthday-bound margin
+/// for realistic corpus sizes (millions of nodes).
+const DEFAULT_BITS: u32 = 52;
+
+/// Mask hashing output down to `bits` bits (never more than 64).
+fn mask_to_bits(v: u64, bits: u32) -> u64 {
+    if bits >= 64 {
+        v
+    } else {
+        v & ((1u64 << bits) - 1)
+    }
+}
+
+/// Pull `bits` bits (<=64) out of a blake3 XOF stream, reading enough
+/// bytes to cover them.
+fn xof_bits(xof: &mut blake3::OutputReader, bits: u32) -> u64 {
+    let nbytes = (bits as usize).div_ceil(8).clamp(1, 8);
+    let mut buf = [0u8; 8];
+    xof.fill(&mut buf[..nbytes]);
+    let v = u64::from_le_bytes(buf);
+    mask_to_bits(v, bits)
+}
+
+/// Given a hasher already fed with the identity bytes, find a value not
+/// already in `seen`, escalating bit width on collision. Inserts the
+/// chosen value into `seen` before returning it.
+fn allocate(hasher: blake3::Hasher, seen: &mut HashSet<u64>) -> u64 {
+    let mut xof = hasher.finalize_xof();
+
+    let mut bits = DEFAULT_BITS;
+    loop {
+        let candidate = xof_bits(&mut xof, bits);
+        if seen.insert(candidate) {
+            return candidate;
+        }
+        if bits >= 64 {
+            // We've exhausted a full u64 read from the xof stream at
+            // this bit width and still collided. Keep widening the xof
+            // read itself (distinct bytes each loop) rather than bit
+            // width, which cannot exceed 64. This should be practically
+            // unreachable — it requires the `seen` set to already
+            // contain the specific 64-bit value derived from this
+            // exact byte window of this exact hash stream — but must
+            // never silently degrade into a duplicate id.
+            let mut guard = 0u32;
+            loop {
+                let mut buf = [0u8; 8];
+                xof.fill(&mut buf);
+                let v = u64::from_le_bytes(buf);
+                if seen.insert(v) {
+                    return v;
+                }
+                guard += 1;
+                assert!(
+                    guard < 1_000_000,
+                    "stable id allocator exhausted escalation without finding a free slot; \
+                     this should be statistically impossible and indicates a bug"
+                );
+            }
+        }
+        bits = (bits * 2).min(64);
+    }
+}
+
+/// Stateful allocator for content-derived `FileId`/`CallableId` values.
+/// One instance is threaded through a whole `analyze_in_pool` run so the
+/// three allocation sites (file/callable merge, exit-node synthesis,
+/// entry-node synthesis) share one `seen` universe and never collide with
+/// each other.
+#[derive(Default)]
+pub struct StableIds {
+    seen_files: HashSet<u64>,
+    seen_callables: HashSet<u64>,
+}
+
+impl StableIds {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Allocate a `FileId` keyed on the file's relative path. Stable
+    /// across content edits — it only changes if the file itself is
+    /// renamed or moved.
+    pub fn file(&mut self, relative_path: &str) -> cgg_core::ids::FileId {
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(b"file\0");
+        hasher.update(relative_path.as_bytes());
+        cgg_core::ids::FileId::new_u64(allocate(hasher, &mut self.seen_files))
+    }
+
+    /// Allocate a `CallableId` keyed on
+    /// `(language, file_path, owner_qualified_name, qualified_name)`.
+    pub fn callable(
+        &mut self,
+        language: &str,
+        file_path: &str,
+        owner_qualified_name: Option<&str>,
+        qualified_name: &str,
+    ) -> cgg_core::ids::CallableId {
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(b"callable\0");
+        hasher.update(language.as_bytes());
+        hasher.update(b"\0");
+        hasher.update(file_path.as_bytes());
+        hasher.update(b"\0");
+        hasher.update(owner_qualified_name.unwrap_or("").as_bytes());
+        hasher.update(b"\0");
+        hasher.update(qualified_name.as_bytes());
+        cgg_core::ids::CallableId::new_u64(allocate(hasher, &mut self.seen_callables))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn same_inputs_produce_the_same_file_id() {
+        let mut a = StableIds::new();
+        let mut b = StableIds::new();
+        assert_eq!(a.file("src/main.rs"), b.file("src/main.rs"));
+    }
+
+    #[test]
+    fn same_inputs_produce_the_same_callable_id() {
+        let mut a = StableIds::new();
+        let mut b = StableIds::new();
+        assert_eq!(
+            a.callable("rust", "src/lib.rs", Some("Widget"), "Widget::new"),
+            b.callable("rust", "src/lib.rs", Some("Widget"), "Widget::new"),
+        );
+    }
+
+    #[test]
+    fn distinct_inputs_do_not_collide_at_typical_corpus_size() {
+        let mut ids = StableIds::new();
+        let mut seen = HashSet::new();
+        // A few tens of thousands of distinct callables, well beyond
+        // what a single-repo run typically extracts.
+        for i in 0..50_000u32 {
+            let qn = format!("module::function_{i}");
+            let id = ids.callable("rust", "src/generated.rs", None, &qn);
+            assert!(seen.insert(id), "unexpected collision at i={i}");
+        }
+    }
+
+    #[test]
+    fn file_ids_are_distinct_for_distinct_paths() {
+        let mut ids = StableIds::new();
+        let mut seen = HashSet::new();
+        for i in 0..20_000u32 {
+            let path = format!("crates/pkg/src/mod_{i}.rs");
+            let id = ids.file(&path);
+            assert!(seen.insert(id), "unexpected file id collision at i={i}");
+        }
+    }
+
+    /// Force a collision by pre-seeding `seen_callables` with the exact
+    /// 52-bit value the next real allocation would otherwise get, and
+    /// confirm the escalation kicks in: the final id differs from the
+    /// seeded value, is deterministic given the same seen-set state, and
+    /// is not simply the colliding value reused.
+    #[test]
+    fn callable_collision_escalates_deterministically() {
+        // First, learn what the natural (unseeded) id would be.
+        let natural = {
+            let mut ids = StableIds::new();
+            ids.callable("python", "app/models.py", Some("User"), "User.save")
+        };
+
+        // Now seed a fresh allocator's `seen` set with that exact value,
+        // forcing the same call to collide and escalate.
+        let mut seeded = StableIds::new();
+        seeded.seen_callables.insert(natural.as_u64());
+        let escalated =
+            seeded.callable("python", "app/models.py", Some("User"), "User.save");
+
+        assert_ne!(
+            escalated, natural,
+            "escalation must not silently reuse the colliding value"
+        );
+        assert_ne!(escalated.as_u64(), natural.as_u64());
+
+        // Deterministic: repeating the exact same seen-set state produces
+        // the exact same escalated id.
+        let mut seeded_again = StableIds::new();
+        seeded_again.seen_callables.insert(natural.as_u64());
+        let escalated_again =
+            seeded_again.callable("python", "app/models.py", Some("User"), "User.save");
+        assert_eq!(escalated, escalated_again);
+    }
+
+    /// Same escalation property for `FileId`.
+    #[test]
+    fn file_collision_escalates_deterministically() {
+        let natural = {
+            let mut ids = StableIds::new();
+            ids.file("src/lib.rs")
+        };
+
+        let mut seeded = StableIds::new();
+        seeded.seen_files.insert(natural.as_u64());
+        let escalated = seeded.file("src/lib.rs");
+
+        assert_ne!(escalated, natural);
+
+        let mut seeded_again = StableIds::new();
+        seeded_again.seen_files.insert(natural.as_u64());
+        let escalated_again = seeded_again.file("src/lib.rs");
+        assert_eq!(escalated, escalated_again);
+    }
+
+    #[test]
+    fn files_and_callables_use_independent_seen_sets() {
+        // A file and a callable can legitimately land on the same raw
+        // hash value without either needing to escalate, because they're
+        // different id types tracked in different `seen` sets.
+        let mut ids = StableIds::new();
+        let f = ids.file("src/lib.rs");
+        // Not asserting equality (vanishingly unlikely) — just that nothing
+        // panics and both allocate independently of one another.
+        let c = ids.callable("rust", "src/lib.rs", None, "lib::main");
+        let _ = (f, c);
+    }
+}

--- a/crates/cgg/src/stable_ids.rs
+++ b/crates/cgg/src/stable_ids.rs
@@ -55,43 +55,45 @@ fn xof_bits(xof: &mut blake3::OutputReader, bits: u32) -> u64 {
 }
 
 /// Given a hasher already fed with the identity bytes, find a value not
-/// already in `seen`, escalating bit width on collision. Inserts the
-/// chosen value into `seen` before returning it.
+/// already in `seen`, drawing successive windows from the item's own
+/// blake3 XOF stream. Inserts the chosen value into `seen` before
+/// returning it.
+///
+/// Every draw is the same width, so **an id never exceeds 52 bits**.
+/// That is deliberate: `cgg-node` binds ids as N-API `i64`, which
+/// reaches JavaScript as a `number`, and a `number` only represents
+/// integers exactly up to 2^53-1. An earlier revision widened to 64
+/// bits on collision, which put every escalated id past that bound and
+/// silently rounded it, so Node reported a different id than the CLI
+/// for the same callable. Staying inside 52 bits keeps all four front
+/// ends agreeing by construction.
+///
+/// Redrawing is a pure function of this item's own hash stream. It
+/// never reads, compares to, or depends on the identity of whichever
+/// other node it collided with — no lexicographic tie-break, no
+/// "whoever sorts first keeps the short form". That is what keeps ids
+/// stable under unrelated edits: a scheme that tie-breaks by comparing
+/// the two colliding parties would flip its answer whenever the set of
+/// nodes changed.
 fn allocate(hasher: blake3::Hasher, seen: &mut HashSet<u64>) -> u64 {
     let mut xof = hasher.finalize_xof();
-
-    let mut bits = DEFAULT_BITS;
+    let mut guard = 0u32;
     loop {
-        let candidate = xof_bits(&mut xof, bits);
+        let candidate = xof_bits(&mut xof, DEFAULT_BITS);
         if seen.insert(candidate) {
             return candidate;
         }
-        if bits >= 64 {
-            // We've exhausted a full u64 read from the xof stream at
-            // this bit width and still collided. Keep widening the xof
-            // read itself (distinct bytes each loop) rather than bit
-            // width, which cannot exceed 64. This should be practically
-            // unreachable — it requires the `seen` set to already
-            // contain the specific 64-bit value derived from this
-            // exact byte window of this exact hash stream — but must
-            // never silently degrade into a duplicate id.
-            let mut guard = 0u32;
-            loop {
-                let mut buf = [0u8; 8];
-                xof.fill(&mut buf);
-                let v = u64::from_le_bytes(buf);
-                if seen.insert(v) {
-                    return v;
-                }
-                guard += 1;
-                assert!(
-                    guard < 1_000_000,
-                    "stable id allocator exhausted escalation without finding a free slot; \
-                     this should be statistically impossible and indicates a bug"
-                );
-            }
-        }
-        bits = (bits * 2).min(64);
+        // Reached only when two callables are genuinely
+        // indistinguishable to cgg — same file, same qualified name,
+        // same signature — or on a true 52-bit hash collision, which
+        // is vanishingly rare. Either way the next window is a fresh,
+        // deterministic draw.
+        guard += 1;
+        assert!(
+            guard < 1_000_000,
+            "stable id allocator exhausted its hash stream without finding a \
+             free slot; this should be statistically impossible and indicates a bug"
+        );
     }
 }
 
@@ -121,14 +123,41 @@ impl StableIds {
         cgg_core::ids::FileId::new_u64(allocate(hasher, &mut self.seen_files))
     }
 
-    /// Allocate a `CallableId` keyed on
-    /// `(language, file_path, owner_qualified_name, qualified_name)`.
+    /// Allocate a `CallableId` keyed on `(language, file_path,
+    /// owner_qualified_name, qualified_name, signature_hint)`.
+    ///
+    /// `signature_hint` is load-bearing, not decoration. Without it the
+    /// key is not unique: a file that declares several callables sharing
+    /// a qualified name — overloads, which C++, C#, Java and Erlang have
+    /// in quantity — hashes them identically. Over the 113-repo
+    /// benchmark corpus that is **309,347 of 1,745,670 callables
+    /// (17.7%)**, peaking at 52.8% in one repo, and every one of them
+    /// falls through to the redraw path in `allocate`, where the id is
+    /// decided by declaration order rather than content. That breaks the
+    /// guarantee this module exists to provide: delete the first of two
+    /// overloads and the second inherits its id, so a consumer diffing
+    /// ids across runs reads "unchanged" while the id now names a
+    /// different function. Adding the signature takes that population to
+    /// **2.25%** — the residual being callables cgg genuinely cannot
+    /// tell apart, where no key can do better.
+    ///
+    /// `start_byte` was measured as an alternative and rejected. It is
+    /// unique corpus-wide, but it churns on movement — one comment line
+    /// added at the top of `spdlog`'s busiest header moved 135 of 1,157
+    /// ids, destroying the diffability this change exists for — and it
+    /// still lets a survivor inherit a deleted sibling's id, because
+    /// removing a definition shifts the next one into its byte offset.
+    ///
+    /// What holds: editing an unrelated file changes nothing, moving
+    /// code within a file changes nothing, and removing one overload
+    /// leaves its siblings alone.
     pub fn callable(
         &mut self,
         language: &str,
         file_path: &str,
         owner_qualified_name: Option<&str>,
         qualified_name: &str,
+        signature_hint: &str,
     ) -> cgg_core::ids::CallableId {
         let mut hasher = blake3::Hasher::new();
         hasher.update(b"callable\0");
@@ -139,6 +168,8 @@ impl StableIds {
         hasher.update(owner_qualified_name.unwrap_or("").as_bytes());
         hasher.update(b"\0");
         hasher.update(qualified_name.as_bytes());
+        hasher.update(b"\0");
+        hasher.update(signature_hint.as_bytes());
         cgg_core::ids::CallableId::new_u64(allocate(hasher, &mut self.seen_callables))
     }
 }
@@ -159,8 +190,20 @@ mod tests {
         let mut a = StableIds::new();
         let mut b = StableIds::new();
         assert_eq!(
-            a.callable("rust", "src/lib.rs", Some("Widget"), "Widget::new"),
-            b.callable("rust", "src/lib.rs", Some("Widget"), "Widget::new"),
+            a.callable(
+                "rust",
+                "src/lib.rs",
+                Some("Widget"),
+                "Widget::new",
+                "fn new()"
+            ),
+            b.callable(
+                "rust",
+                "src/lib.rs",
+                Some("Widget"),
+                "Widget::new",
+                "fn new()"
+            ),
         );
     }
 
@@ -172,7 +215,7 @@ mod tests {
         // what a single-repo run typically extracts.
         for i in 0..50_000u32 {
             let qn = format!("module::function_{i}");
-            let id = ids.callable("rust", "src/generated.rs", None, &qn);
+            let id = ids.callable("rust", "src/generated.rs", None, &qn, "");
             assert!(seen.insert(id), "unexpected collision at i={i}");
         }
     }
@@ -198,7 +241,7 @@ mod tests {
         // First, learn what the natural (unseeded) id would be.
         let natural = {
             let mut ids = StableIds::new();
-            ids.callable("python", "app/models.py", Some("User"), "User.save")
+            ids.callable("python", "app/models.py", Some("User"), "User.save", "")
         };
 
         // Now seed a fresh allocator's `seen` set with that exact value,
@@ -206,7 +249,7 @@ mod tests {
         let mut seeded = StableIds::new();
         seeded.seen_callables.insert(natural.as_u64());
         let escalated =
-            seeded.callable("python", "app/models.py", Some("User"), "User.save");
+            seeded.callable("python", "app/models.py", Some("User"), "User.save", "");
 
         assert_ne!(
             escalated, natural,
@@ -218,8 +261,13 @@ mod tests {
         // the exact same escalated id.
         let mut seeded_again = StableIds::new();
         seeded_again.seen_callables.insert(natural.as_u64());
-        let escalated_again =
-            seeded_again.callable("python", "app/models.py", Some("User"), "User.save");
+        let escalated_again = seeded_again.callable(
+            "python",
+            "app/models.py",
+            Some("User"),
+            "User.save",
+            "",
+        );
         assert_eq!(escalated, escalated_again);
     }
 
@@ -243,6 +291,61 @@ mod tests {
         assert_eq!(escalated, escalated_again);
     }
 
+    /// The case that actually occurs, and that nothing covered before:
+    /// two callables in ONE file sharing a qualified name — overloads —
+    /// allocated from ONE `StableIds`. On `(language, file, owner, qn)`
+    /// alone these hash identically, so the second escalated and its id
+    /// became a function of declaration order; deleting the first then
+    /// handed its id to the second. Distinct signatures must now yield
+    /// distinct ids with no escalation, and removing one must leave the
+    /// other's id untouched.
+    #[test]
+    fn overloads_in_one_file_get_distinct_ids_that_survive_a_sibling_removal() {
+        let (f, qn, owner) = ("src/shape.cpp", "Shape::area", Some("Shape"));
+        let (sig1, sig2) = ("int area(int w)", "int area(int w, int h)");
+
+        let mut both = StableIds::new();
+        let first = both.callable("cpp", f, owner, qn, sig1);
+        let second = both.callable("cpp", f, owner, qn, sig2);
+        assert_ne!(first, second, "overloads must not share an id");
+
+        // Both fit in 52 bits, so both survive the trip through
+        // cgg-node's `number` binding intact.
+        assert!(first.as_u64() < 1 << 52, "first exceeds 52 bits: {first}");
+        assert!(
+            second.as_u64() < 1 << 52,
+            "second exceeds 52 bits: {second}"
+        );
+
+        // Delete the first overload. The second keeps its own id rather
+        // than inheriting the departed one's — the silent-corruption
+        // case, where a stale id still resolves but names something else.
+        let mut survivor = StableIds::new();
+        assert_eq!(
+            survivor.callable("cpp", f, owner, qn, sig2),
+            second,
+            "surviving overload's id must not depend on a sibling"
+        );
+    }
+
+    /// Two callables cgg genuinely cannot tell apart — same file, same
+    /// qualified name, same signature — still get distinct ids, and both
+    /// stay inside 52 bits so neither is corrupted by `cgg-node`'s
+    /// `number` binding.
+    #[test]
+    fn indistinguishable_siblings_still_get_distinct_js_safe_ids() {
+        let mut ids = StableIds::new();
+        let a = ids.callable("erlang", "src/m.erl", None, "m:go", "");
+        let b = ids.callable("erlang", "src/m.erl", None, "m:go", "");
+        assert_ne!(a, b, "a redraw must not hand out the same value twice");
+        for id in [a, b] {
+            assert!(
+                id.as_u64() < 1 << 52,
+                "id {id} exceeds 52 bits and is unsafe as a JS number"
+            );
+        }
+    }
+
     #[test]
     fn files_and_callables_use_independent_seen_sets() {
         // A file and a callable can legitimately land on the same raw
@@ -252,7 +355,7 @@ mod tests {
         let f = ids.file("src/lib.rs");
         // Not asserting equality (vanishingly unlikely) — just that nothing
         // panics and both allocate independently of one another.
-        let c = ids.callable("rust", "src/lib.rs", None, "lib::main");
+        let c = ids.callable("rust", "src/lib.rs", None, "lib::main", "");
         let _ = (f, c);
     }
 }

--- a/crates/cgg/tests/link.rs
+++ b/crates/cgg/tests/link.rs
@@ -41,10 +41,15 @@ fn end() {}
 
     let g = fs::read_to_string(&mmd).unwrap();
     assert!(g.starts_with("flowchart LR\n"));
-    // Three callables -> three C<n> nodes.
-    assert!(g.contains("C0"));
-    assert!(g.contains("C1"));
-    assert!(g.contains("C2"));
+    // Three callables -> three distinct `C<base36-token>` nodes. Ids are
+    // content-derived hashes now, not sequential, so assert on shape
+    // rather than exact values.
+    let node_re = regex::Regex::new(r"(?m)^  C([0-9a-z]+)\[").unwrap();
+    let node_ids: std::collections::HashSet<&str> = node_re
+        .captures_iter(&g)
+        .map(|c| c.get(1).unwrap().as_str())
+        .collect();
+    assert_eq!(node_ids.len(), 3, "want three distinct nodes:\n{g}");
     // Two edges: start -> middle, middle -> end.
     let arrow_count = g.matches(" --> ").count();
     assert_eq!(arrow_count, 2, "mermaid:\n{g}");
@@ -76,14 +81,17 @@ fn fib(n: u32) -> u32 { if n < 2 { n } else { fib(n - 1) + fib(n - 2) } }
     // renderer collapses parallel call sites into a single arrow with
     // a `|Nx|` label when the same caller calls the same callee more
     // than once, so for `fib` (two recursive calls) we expect either
-    // the bare `C0 --> C0` form (one site) or the labelled form
-    // (multiple sites). Either proves the cycle wasn't dropped.
+    // the bare `C<id> --> C<id>` form (one site) or the labelled form
+    // (multiple sites). Either proves the cycle wasn't dropped. Ids are
+    // content-derived hashes now, so match the shape rather than a
+    // literal `C0`.
     assert!(g.contains("fib"));
-    let has_bare = g.contains("C0 --> C0");
-    let has_labelled = g
-        .lines()
-        .any(|l| l.starts_with("  C0 -->|") && l.ends_with("| C0"));
-    assert!(has_bare || has_labelled, "want self-edge:\n{g}");
+    let self_edge_re =
+        regex::Regex::new(r"(?m)^  C([0-9a-z]+) -->(\|[^|]*\|)? C([0-9a-z]+)$").unwrap();
+    let has_self_edge = self_edge_re
+        .captures_iter(&g)
+        .any(|c| c.get(1).unwrap().as_str() == c.get(3).unwrap().as_str());
+    assert!(has_self_edge, "want self-edge:\n{g}");
 }
 
 #[test]

--- a/scripts/docs-check.py
+++ b/scripts/docs-check.py
@@ -628,7 +628,9 @@ def check_self_analysis_showcase() -> None:
     block = m.group(1)
     crates = {
         n.split("::")[0]
-        for n in re.findall(r'^\s*C\d+\["([^"]+)"\]', block, re.MULTILINE)
+        # Node ids are content-derived base36 hashes now (e.g. `Ce8btaz0c7d`),
+        # not sequential decimals — match the id shape, not `\d+`.
+        for n in re.findall(r'^\s*C[0-9a-z]+\["([^"]+)"\]', block, re.MULTILINE)
     }
     if len(crates) < 3:
         fail(

--- a/scripts/update-readme-graphs.py
+++ b/scripts/update-readme-graphs.py
@@ -75,7 +75,11 @@ def clean(mmd_text: str) -> str:
         return lbl.replace("crate::", "").replace("&lt;", "<").replace("&gt;", ">")
 
     out = ["flowchart LR"]
-    for nid in sorted(keep, key=lambda x: int(x[1:])):
+    # Node ids are content-derived base36 hashes now, not sequential
+    # integers, so there's no numeric value to sort by — `nodes` already
+    # preserves cgg's own (deterministic) emission order, which is what
+    # we want anyway.
+    for nid in nodes:
         out.append(f'  {nid}["{tidy(nodes[nid])}"]')
     for (s, d), lbl in sorted(edges.items()):
         arrow = f"-->|{lbl}|" if lbl else "-->"

--- a/skills/cgg-install/SKILL.md
+++ b/skills/cgg-install/SKILL.md
@@ -208,13 +208,15 @@ printf 'def a():\n    return b()\n\ndef b():\n    return 1\n' > /tmp/cgg-smoke/t
 cgg /tmp/cgg-smoke
 ```
 
-Expected output, exactly:
+Expected output (node ids are content-derived, so they are stable for
+this exact input but are not sequential — the two labels and the one
+arrow are what to check):
 
 ```text
 flowchart LR
-  C0["t.a"]
-  C1["t.b"]
-  C0 --> C1
+  C15ok5bo1gvr["t.a"]
+  Cqvd8tmwlzt["t.b"]
+  C15ok5bo1gvr --> Cqvd8tmwlzt
 ```
 
 If the user *does* have the source tree, run cgg against itself:

--- a/skills/cgg/SKILL.md
+++ b/skills/cgg/SKILL.md
@@ -155,8 +155,9 @@ keys are `callables`, `files`, `edges`, `unresolved`, `file_audits`,
 - **`callables` is an object keyed by stringified id, not an array** —
   `.callables[]` iterates values, but `.callables[0]` is an error. Each
   value has `qualified_name`, `simple_name`, `kind`, `language`, `file`
-  (an index into `files`), `start_line`/`end_line`, `signature_hint`,
-  `visibility`.
+  (the owning file's **id** — look it up as a key of `files`, which is
+  also an object keyed by id; it is not an array offset),
+  `start_line`/`end_line`, `signature_hint`, `visibility`.
 - **Edges use `src`/`dst`, not `from`/`to`**, and carry `site_line`,
   `site_byte`, `confidence`, `via`, `resolver`.
 
@@ -164,8 +165,8 @@ keys are `callables`, `files`, `edges`, `unresolved`, `file_audits`,
 # every callee of a given caller, by name
 jq -r --arg fn 'cgg::analyze_in_pool' '
   (.callables | with_entries({key: .key, value: .value.qualified_name})) as $name
-  | [ $name | to_entries[] | select(.value == $fn) | .key | tonumber ] as $ids
-  | .edges[] | select(.src as $s | $ids | index($s)) | $name[(.dst|tostring)]
+  | [ $name | to_entries[] | select(.value == $fn) | .key ] as $ids
+  | .edges[] | select(.src as $s | $ids | index($s)) | $name[.dst]
 ' /tmp/graph.json | sort -u
 ```
 
@@ -212,11 +213,11 @@ handler would otherwise have in-degree zero — which is a claim
 %% in your source; they represent control entering from a framework.
 %% BEST EFFORT — see the coverage table for what cgg did and did not recognise.
 flowchart LR
-  C0["svc.list_users"]
-  C1["app.list_users"]
-  C2["&lt;framework-entry&gt;::network::flask::route('/users') ⟨framework entry callback⟩"]
-  C1 --> C0
-  C2 -->|entry| C1
+  Cq3rc7yk1ma["svc.list_users"]
+  C1e0h9zwbxof["app.list_users"]
+  C8tjm5nd42p["&lt;framework-entry&gt;::network::flask::route('/users') ⟨framework entry callback⟩"]
+  C1e0h9zwbxof --> Cq3rc7yk1ma
+  C8tjm5nd42p -->|entry| C1e0h9zwbxof
 ```
 
 Note the mermaid escaping: the emitted label is `&lt;framework-entry&gt;`,
@@ -345,13 +346,22 @@ A mermaid flowchart from cgg looks like this (real output of
 
 ```text
 flowchart LR
-  C269["cgg::analyze_in_pool"]
-  C278["cgg::read_file"]
-  C269 --> C278
+  Ck6rdns31fh["cgg::analyze_in_pool"]
+  C1a7yv3q0ebt["cgg::read_file"]
+  Ck6rdns31fh --> C1a7yv3q0ebt
 ```
 
-Node ids (`C269`) are positional and have no meaning across runs —
-never quote them back to the user, quote the labels.
+Node ids (`Ck6rdns31fh`) are a type prefix plus lowercase base36 digits,
+derived by hashing the callable's identity — **not** a sequential index.
+The same callable keeps the same id across runs of the same tree, so ids
+are comparable between two runs: editing an unrelated file, or moving
+code within a file, leaves an id alone. Two caveats before you rely on
+that. Ids are not comparable across cgg *versions*. And where cgg
+genuinely cannot tell two callables apart — same file, same qualified
+name, same signature — it separates them by declaration order, so
+removing one can hand its id to the other; that is rare, and overloads
+with distinct signatures are not affected. Still quote the labels to
+the user, not the ids.
 
 Each node is a callable, labeled with its fully-qualified name. Each
 edge is a *resolved* call site — cgg doesn't emit edges it can't
@@ -360,8 +370,9 @@ the graph with guesses.
 
 When the same caller calls the same callee at multiple distinct call
 sites in the source, the mermaid and dot renderers collapse those
-into a single arrow with a multiplicity label — e.g. `C269 -->|18x| C1989`
-in mermaid, or `n269 -> n1989 [label="18x"];` in dot. The bare arrow form
+into a single arrow with a multiplicity label — e.g.
+`Ck6rdns31fh -->|18x| C1a7yv3q0ebt` in mermaid, or
+`nk6rdns31fh -> n1a7yv3q0ebt [label="18x"];` in dot. The bare arrow form
 is used when the count is 1. When an edge also carries a `Via` tag the
 label slot holds both, space-separated: `-->|std 9x|`, `-->|ref 10x|`.
 JSON and GraphML still emit one edge per call site (with


### PR DESCRIPTION
Replace sequential u32 CallableId/FileId, assigned by run-order
counters, with blake3-hash-derived u64 IDs encoded as base36 on the
wire. IDs are now a pure function of (language, file path, owner,
qualified name) instead of insertion order, so editing or renaming an
unrelated file no longer renumbers every callable that happens to sort
after it. Collisions (52-bit default width) are resolved by pulling
more bits from the same blake3 XOF stream for the colliding item only,
never by comparing to or depending on sibling nodes, so an id can only
change if it itself starts colliding with something new.

- cgg-core: CallableId/FileId widened to u64; Display is now base36;
  Serialize/Deserialize go through Display/FromStr (ids are JSON
  strings, not numbers).
- cgg: new stable_ids::StableIds allocator replaces the next_file_id/
  next_callable_id counters at all three allocation sites.
- cgg-format: mermaid/dot/graphml emit the base36 token instead of a
  decimal, keeping each format's own prefix character. json.rs is
  unchanged (ids now come through as strings automatically).
- cgg-resolve: dedup/sort keys now hold `CallableId`/`FileId` directly
  (they're already typed newtypes over u64 — Hash + Eq + Ord) instead
  of erasing to raw integers.
- cgg-py: Callable/Edge/File id fields moved to u64.
- cgg-node: id fields moved to i64/bigint (napi has no u64); fixed a
  latent bug where Graph.files was only safe to index by Callable.file
  because ids used to be sequential — it now returns {id, path} pairs.
- cgg-ffi: unaffected, never exposed raw ids.
- scripts/update-readme-graphs.py, scripts/docs-check.py: fixed two
  places that assumed decimal node ids (sort key, crate-count regex).
- README regenerated (self-analysis showcase, walk/lang graphs, stats).

**Breaking:** numeric ids from prior versions are not comparable
across runs or versions; anything storing/diffing raw ids needs to
switch to the string form. No numbers claimed for the extra
per-callable hash cost yet — needs a `scripts/perf-compare.sh` run
before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)